### PR TITLE
[UPD] ssi_financial_accounting_operating_unit

### DIFF
--- a/ssi_financial_accounting_operating_unit/__manifest__.py
+++ b/ssi_financial_accounting_operating_unit/__manifest__.py
@@ -14,14 +14,18 @@
         "ssi_operating_unit_mixin",
     ],
     "data": [
+        "security/res_group/journal_entry.xml",
+        "security/res_group/bank_statement.xml",
         "security/ir_rule/account_journal.xml",
         "security/ir_rule/account_move.xml",
         "security/ir_rule/account_move_line.xml",
         "security/ir_rule/account_bank_statement.xml",
+        "security/ir_rule/account_payment.xml",
         "views/account_journal_views.xml",
         "views/account_move_views.xml",
         "views/account_move_line_views.xml",
         "views/account_bank_statement_views.xml",
+        "views/account_payment_views.xml",
     ],
     "demo": [],
 }

--- a/ssi_financial_accounting_operating_unit/models/__init__.py
+++ b/ssi_financial_accounting_operating_unit/models/__init__.py
@@ -8,4 +8,5 @@ from . import (
     account_move_line,
     account_bank_statement,
     account_bank_statement_line,
+    account_statement_import,
 )

--- a/ssi_financial_accounting_operating_unit/models/account_bank_statement_line.py
+++ b/ssi_financial_accounting_operating_unit/models/account_bank_statement_line.py
@@ -11,6 +11,12 @@ class AccountBankStatementLine(models.Model):
         "account.bank.statement.line",
     ]
 
+    # operating_unit_id is obtained via _inherits delegation to account.move
+    # (see ssi_financial_accounting_operating_unit/models/account_move.py),
+    # not via mixin.single_operating_unit on this model. Do NOT add the mixin
+    # here — it would define a local field and break the delegation, causing
+    # the vals["operating_unit_id"] set below to write to the line instead of
+    # propagating to move_id.
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:

--- a/ssi_financial_accounting_operating_unit/models/account_move.py
+++ b/ssi_financial_accounting_operating_unit/models/account_move.py
@@ -25,13 +25,13 @@ class AccountMove(models.Model):
     def _onchange_operating_unit(self):
         if self.operating_unit_id and (
             not self.journal_id
-            or self.journal_id.operating_unit_ids.id not in [self.operating_unit_id]
+            or self.operating_unit_id not in self.journal_id.operating_unit_ids
         ):
             journal = self.env["account.journal"].search(
                 [("type", "=", self.journal_id.type)]
             )
             jf = journal.filtered(
-                lambda aj: aj.operating_unit_ids.id in [self.operating_unit_id]
+                lambda aj: self.operating_unit_id in aj.operating_unit_ids
             )
             if not jf:
                 self.journal_id = journal[0]
@@ -45,7 +45,7 @@ class AccountMove(models.Model):
         if (
             self.journal_id
             and self.journal_id.operating_unit_ids
-            and self.journal_id.operating_unit_ids.id not in [self.operating_unit_id.id]
+            and self.operating_unit_id not in self.journal_id.operating_unit_ids
         ):
             self.operating_unit_id = self.journal_id.operating_unit_ids[0]
             for line in self.line_ids:
@@ -60,12 +60,21 @@ class AccountMove(models.Model):
                 and move.operating_unit_id.id
                 not in move.journal_id.operating_unit_ids.ids
             ):
+                # If already inside a self-heal cycle, stop immediately to prevent
+                # infinite recursion — constraint calls onchange which triggers
+                # constraint again when no matching journal is found.
+                if move._context.get("_ou_check_journal_healing"):
+                    raise UserError(
+                        _("The OU in the Move and in Journal must be the same.")
+                    )
                 # Change journal_id if create move from other model. e.g., sale.order
                 if (
                     move._context.get("active_model")
                     and move._context.get("active_model") != "account.move"
                 ):
-                    move._onchange_operating_unit()
+                    move.with_context(
+                        _ou_check_journal_healing=True
+                    )._onchange_operating_unit()
                     if (
                         move.journal_id.operating_unit_ids
                         and move.operating_unit_id

--- a/ssi_financial_accounting_operating_unit/models/account_statement_import.py
+++ b/ssi_financial_accounting_operating_unit/models/account_statement_import.py
@@ -1,0 +1,25 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountStatementImport(models.TransientModel):
+    _inherit = "account.statement.import"
+
+    def _complete_stmts_vals(self, stmts_vals, journal, account_number):
+        stmts_vals = super()._complete_stmts_vals(stmts_vals, journal, account_number)
+        ous = journal.operating_unit_ids
+        for st_vals in stmts_vals:
+            if st_vals.get("operating_unit_id"):
+                continue
+            if len(ous) == 1:
+                st_vals["operating_unit_id"] = ous.id
+            elif len(ous) > 1:
+                default_ou = self.env["res.users"].operating_unit_default_get()
+                st_vals["operating_unit_id"] = (
+                    default_ou.id if default_ou in ous else ous[0].id
+                )
+            # journal without OU: leave default (no mismatch possible)
+        return stmts_vals

--- a/ssi_financial_accounting_operating_unit/security/ir_rule/account_bank_statement.xml
+++ b/ssi_financial_accounting_operating_unit/security/ir_rule/account_bank_statement.xml
@@ -5,15 +5,14 @@
 <odoo>
 <record id="account_bank_statement_rule_ou" model="ir.rule">
     <field name="model_id" ref="account.model_account_bank_statement" />
+    <field name="groups" eval="[(4, ref('bank_statement_ou_group'))]" />
     <field name="domain_force">
-        ['|', ('operating_unit_id','=',False),
-        ('operating_unit_id','in',user.operating_unit_ids.ids)]
+        [('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
     </field>
-    <field name="name">account.move - ou</field>
-    <field name="global" eval="True" />
-    <field eval="0" name="perm_unlink" />
-    <field eval="0" name="perm_write" />
+    <field name="name">account.bank.statement - ou</field>
+    <field eval="1" name="perm_unlink" />
+    <field eval="1" name="perm_write" />
     <field eval="1" name="perm_read" />
-    <field eval="0" name="perm_create" />
+    <field eval="1" name="perm_create" />
 </record>
 </odoo>

--- a/ssi_financial_accounting_operating_unit/security/ir_rule/account_move.xml
+++ b/ssi_financial_accounting_operating_unit/security/ir_rule/account_move.xml
@@ -5,15 +5,14 @@
 <odoo>
 <record id="account_move_rule_ou" model="ir.rule">
     <field name="model_id" ref="account.model_account_move" />
+    <field name="groups" eval="[(4, ref('journal_entry_ou_group'))]" />
     <field name="domain_force">
-        ['|', ('operating_unit_id','=',False),
-        ('operating_unit_id','in',user.operating_unit_ids.ids)]
+        [('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
     </field>
     <field name="name">account.move - ou</field>
-    <field name="global" eval="True" />
-    <field eval="0" name="perm_unlink" />
-    <field eval="0" name="perm_write" />
+    <field eval="1" name="perm_unlink" />
+    <field eval="1" name="perm_write" />
     <field eval="1" name="perm_read" />
-    <field eval="0" name="perm_create" />
+    <field eval="1" name="perm_create" />
 </record>
 </odoo>

--- a/ssi_financial_accounting_operating_unit/security/ir_rule/account_move_line.xml
+++ b/ssi_financial_accounting_operating_unit/security/ir_rule/account_move_line.xml
@@ -5,15 +5,14 @@
 <odoo>
 <record id="account_move_line_rule_ou" model="ir.rule">
     <field name="model_id" ref="account.model_account_move_line" />
+    <field name="groups" eval="[(4, ref('journal_entry_ou_group'))]" />
     <field name="domain_force">
-        ['|', ('operating_unit_id','=',False),
-        ('operating_unit_id','in',user.operating_unit_ids.ids)]
+        [('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
     </field>
     <field name="name">account.move.line - ou</field>
-    <field name="global" eval="True" />
-    <field eval="0" name="perm_unlink" />
-    <field eval="0" name="perm_write" />
+    <field eval="1" name="perm_unlink" />
+    <field eval="1" name="perm_write" />
     <field eval="1" name="perm_read" />
-    <field eval="0" name="perm_create" />
+    <field eval="1" name="perm_create" />
 </record>
 </odoo>

--- a/ssi_financial_accounting_operating_unit/security/ir_rule/account_payment.xml
+++ b/ssi_financial_accounting_operating_unit/security/ir_rule/account_payment.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="account_payment_rule_ou" model="ir.rule">
+    <field name="model_id" ref="account.model_account_payment" />
+    <field name="groups" eval="[(4, ref('journal_entry_ou_group'))]" />
+    <field name="domain_force">
+        [('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
+    </field>
+    <field name="name">account.payment - ou</field>
+    <field eval="1" name="perm_unlink" />
+    <field eval="1" name="perm_write" />
+    <field eval="1" name="perm_read" />
+    <field eval="1" name="perm_create" />
+</record>
+</odoo>

--- a/ssi_financial_accounting_operating_unit/security/res_group/bank_statement.xml
+++ b/ssi_financial_accounting_operating_unit/security/res_group/bank_statement.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="bank_statement_ou_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_financial_accounting.bank_statement_data_ownership_module_category"
+        />
+</record>
+
+<record id="ssi_financial_accounting.bank_statement_company_group" model="res.groups">
+    <field name="implied_ids" eval="[(4, ref('bank_statement_ou_group'))]" />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+</record>
+</odoo>

--- a/ssi_financial_accounting_operating_unit/security/res_group/journal_entry.xml
+++ b/ssi_financial_accounting_operating_unit/security/res_group/journal_entry.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="journal_entry_ou_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_financial_accounting.journal_entry_data_ownership_module_category"
+        />
+</record>
+
+<record id="ssi_financial_accounting.journal_entry_company_group" model="res.groups">
+    <field name="implied_ids" eval="[(4, ref('journal_entry_ou_group'))]" />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+</record>
+</odoo>

--- a/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
+++ b/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
@@ -2,6 +2,7 @@
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo import fields
 from odoo.tests import TransactionCase, tagged
 
 
@@ -59,3 +60,106 @@ class TestSsiFinancialAccountingOperatingUnit(TransactionCase):
             }
         )
         self.assertEqual(move.state, "draft")
+
+    def test_bank_statement_line_ou_via_delegation_not_mixin(self):
+        """Regression: account.bank.statement.line gets operating_unit_id via
+        _inherits delegation from account.move — NOT from mixin.single_operating_unit.
+        Adding the mixin would break the delegation field. This test verifies the field
+        exists via delegation.
+        """
+        model = self.env["account.bank.statement.line"]
+
+        # Field must exist (via delegation from account.move)
+        fields_info = model.fields_get(["operating_unit_id"])
+        self.assertIn("operating_unit_id", fields_info)
+
+        # The field originates from account.move via _inherits delegation,
+        # so it must NOT be declared as a local field on the model itself.
+        local_fields = model._fields
+        local_field = local_fields.get("operating_unit_id")
+        # A delegated field has model_name pointing to the delegated model
+        self.assertEqual(
+            local_field.related_field.model_name if local_field else None,
+            "account.move",
+            "operating_unit_id on account.bank.statement.line must be a "
+            "delegation field originating from account.move, not a mixin field.",
+        )
+
+    def test_bank_statement_line_ou_propagated_from_statement(self):
+        """Regression: creating a bank.statement.line should carry the OU of the
+        parent bank.statement when OU is set on the statement.
+        """
+        journal = self.env["account.journal"].search([("type", "=", "bank")], limit=1)
+        if not journal or not self.operating_unit:
+            self.skipTest("No bank journal or operating unit found")
+
+        statement = self.env["account.bank.statement"].create(
+            {
+                "name": "Test OU Propagation",
+                "journal_id": journal.id,
+                "operating_unit_id": self.operating_unit.id,
+            }
+        )
+        self.assertEqual(statement.operating_unit_id, self.operating_unit)
+
+        line = self.env["account.bank.statement.line"].create(
+            {
+                "statement_id": statement.id,
+                "payment_ref": "Test Line OU",
+                "amount": 100.0,
+                "date": fields.Date.today(),
+            }
+        )
+        self.assertEqual(
+            line.operating_unit_id,
+            self.operating_unit,
+            "bank.statement.line.operating_unit_id must equal the parent "
+            "statement's operating_unit_id (propagated via create() override, "
+            "stored on account.move via delegation).",
+        )
+
+    def test_account_payment_ou_via_delegation(self):
+        """Regression: account.payment exposes operating_unit_id via
+        _inherits delegation to account.move (same pattern as
+        bank.statement.line, BL-0003) — NOT via mixin.single_operating_unit
+        added directly to account.payment.
+        """
+        model = self.env["account.payment"]
+
+        fields_info = model.fields_get(["operating_unit_id"])
+        self.assertIn("operating_unit_id", fields_info)
+
+        local_field = model._fields.get("operating_unit_id")
+        self.assertEqual(
+            local_field.related_field.model_name if local_field else None,
+            "account.move",
+            "operating_unit_id on account.payment must be a delegation "
+            "field originating from account.move, not a mixin field.",
+        )
+
+        journal = self.env["account.journal"].search(
+            [("type", "in", ("bank", "cash"))], limit=1
+        )
+        partner = self.env["res.partner"].search([], limit=1)
+        if not journal or not partner or not self.operating_unit:
+            self.skipTest("No journal/partner/operating unit found")
+
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": journal.id,
+                "partner_id": partner.id,
+                "amount": 100.0,
+                "operating_unit_id": self.operating_unit.id,
+            }
+        )
+        self.assertEqual(
+            payment.operating_unit_id,
+            self.operating_unit,
+            "Setting operating_unit_id on account.payment must persist via "
+            "delegation to the underlying account.move (move_id).",
+        )
+        self.assertEqual(
+            payment.move_id.operating_unit_id,
+            self.operating_unit,
+            "account.payment.operating_unit_id must delegate to move_id.",
+        )

--- a/ssi_financial_accounting_operating_unit/views/account_bank_statement_views.xml
+++ b/ssi_financial_accounting_operating_unit/views/account_bank_statement_views.xml
@@ -35,4 +35,23 @@
         </data>
     </field>
 </record>
+
+<record model="ir.ui.view" id="account_bank_statement_view_search">
+    <field name="name">account.bank.statement - search</field>
+    <field name="model">account.bank.statement</field>
+    <field name="inherit_id" ref="account.view_bank_statement_search" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//filter[@name='date']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
 </odoo>

--- a/ssi_financial_accounting_operating_unit/views/account_journal_views.xml
+++ b/ssi_financial_accounting_operating_unit/views/account_journal_views.xml
@@ -38,4 +38,30 @@
       </data>
     </field>
 </record>
+
+<record id="account_journal_view_search" model="ir.ui.view">
+    <field name="name">account.journal - search</field>
+    <field name="model">account.journal</field>
+    <field name="inherit_id" ref="account.view_account_journal_search" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='name']" position="after">
+                <field
+                        name="operating_unit_ids"
+                        string="Operating Unit"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+            <xpath expr="//filter[@name='inactive']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_ids'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
 </odoo>

--- a/ssi_financial_accounting_operating_unit/views/account_move_line_views.xml
+++ b/ssi_financial_accounting_operating_unit/views/account_move_line_views.xml
@@ -35,4 +35,23 @@
         </data>
     </field>
 </record>
+
+<record model="ir.ui.view" id="account_move_line_view_search">
+    <field name="name">account.move.line - search</field>
+    <field name="model">account.move.line</field>
+    <field name="inherit_id" ref="account.view_account_move_line_filter" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//filter[@name='groupby_date']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
 </odoo>

--- a/ssi_financial_accounting_operating_unit/views/account_move_views.xml
+++ b/ssi_financial_accounting_operating_unit/views/account_move_views.xml
@@ -3,6 +3,43 @@
      Copyright 2022 PT. Simetri Sinergi Indonesia
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
+<record model="ir.ui.view" id="account_move_view_search">
+    <field name="name">account.move - search</field>
+    <field name="model">account.move</field>
+    <field name="inherit_id" ref="account.view_account_move_filter" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//filter[@name='by_company']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record model="ir.ui.view" id="account_invoice_view_search">
+    <field name="name">account.invoice - search</field>
+    <field name="model">account.move</field>
+    <field name="inherit_id" ref="account.view_account_invoice_filter" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//filter[@name='duedate']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+
 <record model="ir.ui.view" id="account_move_view_form">
     <field name="name">account.move - form</field>
     <field name="model">account.move</field>

--- a/ssi_financial_accounting_operating_unit/views/account_payment_views.xml
+++ b/ssi_financial_accounting_operating_unit/views/account_payment_views.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record model="ir.ui.view" id="account_payment_view_tree">
+    <field name="name">account.payment - tree</field>
+    <field name="model">account.payment</field>
+    <field name="inherit_id" ref="account.view_account_payment_tree" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record model="ir.ui.view" id="account_payment_view_search">
+    <field name="name">account.payment - search</field>
+    <field name="model">account.payment</field>
+    <field name="inherit_id" ref="account.view_account_payment_search" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+            <xpath expr="//filter[@name='company']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</odoo>


### PR DESCRIPTION
## Ringkasan

Rangkaian perbaikan & fitur Operating Unit pada `ssi_financial_accounting_operating_unit`:

* **BL-0003** — Regression test: `operating_unit_id` pada `account.bank.statement.line` diperoleh via delegasi `_inherits` ke `account.move`, bukan mixin — mengunci perilaku ini agar tidak "diperbaiki" keliru dengan menambah mixin.
* **BL-0004** — Perbaiki nama `ir.rule` `account_bank_statement_rule_ou` yang salah tertulis `"account.move - ou"`.
* **BL-0005** — Perbaiki bug perbandingan `int` vs recordset di `_onchange_operating_unit` dan `_onchange_journal` (`account.move`) — journal tidak lagi selalu di-reset, dan tidak lagi crash `Expected singleton` pada journal multi-OU.
* **BL-0006** — Konversi `ir.rule` `account.move`, `account.move.line`, `account.bank.statement`, `account.payment` dari **global rule** menjadi **group-scoped** ke grup Operating Unit baru (breaking change, lihat catatan di bawah).
* **BL-0007** — Tambah search view inheritance (filter & group-by Operating Unit) untuk `account.move`, `account.bank.statement`, `account.move.line`, `account.journal`.
* **BL-0009** — Tambah dukungan Operating Unit untuk `account.payment` (ir.rule + view), menutup gap terhadap modul OCA `account_operating_unit`.
* **BL-0010** — Override `_complete_stmts_vals` pada `account.statement.import` agar `operating_unit_id` statement hasil import diambil dari journal — mencegah mismatch OU antara move dan journal.
* **BL-0011** — Guard re-entrancy pada `_check_journal_operating_unit` agar tidak memicu `RecursionError` saat tidak ada journal yang cocok dengan OU.

BL-0005 + BL-0010 + BL-0011 bersama-sama menutup `RecursionError` yang terverifikasi terjadi (rantai rekursi 83x) saat import bank statement ketika OU default user berbeda dengan OU journal bank.

## ⚠️ Breaking change (BL-0006)

`ir.rule` untuk `account.move`, `account.move.line`, `account.bank.statement`, dan `account.payment` tidak lagi berupa global rule — kini hanya berlaku bagi user yang memiliki grup "Operating Unit" (turunan dari grup "Company" pada masing-masing kategori data ownership). User yang belum ter-assign grup ini akan kehilangan filter OU pada model-model tersebut. Pastikan grup data ownership sudah ter-assign ke user yang relevan sebelum deploy ke production.

## Test plan
- [x] `odoo -u ssi_financial_accounting_operating_unit --test-enable` → 0 failed, 0 error
- [x] `pre-commit run --all-files` → semua hook passed
- [x] Verifikasi manual via `odoo shell`: grup & ir.rule baru sesuai kriteria penerimaan masing-masing item backlog