### PR TITLE
[UPD] ssi_account_statement_import_pdf_image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 # generated from manifests external_dependencies
+numpy
+opencv-python-headless
 pdf2image
 pdfplumber
 pytesseract

--- a/setup/ssi_account_statement_import_pdf_image/setup.py
+++ b/setup/ssi_account_statement_import_pdf_image/setup.py
@@ -2,5 +2,9 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        "external_dependencies_override": {
+            "python": {"cv2": "opencv-python-headless"},
+        },
+    },
 )

--- a/ssi_account_statement_import_pdf_image/README.rst
+++ b/ssi_account_statement_import_pdf_image/README.rst
@@ -13,7 +13,14 @@ restricted Python environment (safe_eval), applied to the OCR-extracted text.
 
 This module requires the system binaries ``tesseract-ocr`` and
 ``poppler-utils`` to be installed on the Odoo image, in addition to the
-Python packages ``pytesseract`` and ``pdf2image``.
+Python packages ``pytesseract``, ``pdf2image``, ``opencv-python-headless``
+and ``numpy``.
+
+Each mapping record can optionally enable image preprocessing (grayscale,
+auto contrast, binarization, deskew, upscale) applied to every rendered page
+before OCR. This is disabled by default and is intended for low-quality
+scans (e.g. photocopied passbooks) where raw OCR output is too noisy for
+``parser_code`` to parse.
 
 
 Bug Tracker

--- a/ssi_account_statement_import_pdf_image/__manifest__.py
+++ b/ssi_account_statement_import_pdf_image/__manifest__.py
@@ -13,7 +13,7 @@
         "ssi_account_statement_import",
     ],
     "external_dependencies": {
-        "python": ["pytesseract", "pdf2image"],
+        "python": ["pytesseract", "pdf2image", "cv2", "numpy"],
     },
     "data": [
         "security/res_groups/account_statement_import_pdf_image_mapping.xml",

--- a/ssi_account_statement_import_pdf_image/models/account_statement_import_pdf_image_mapping.py
+++ b/ssi_account_statement_import_pdf_image/models/account_statement_import_pdf_image_mapping.py
@@ -1,6 +1,10 @@
 # Copyright 2026 OpenSynergy Indonesia
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import cv2
+import numpy
+from PIL import Image
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 from odoo.tools.safe_eval import safe_eval, wrap_module
@@ -72,6 +76,161 @@ class AccountStatementImportPdfImageMapping(models.Model):
             "result['account_number'] (str or None)."
         ),
     )
+    preprocess_enabled = fields.Boolean(
+        string="Enable Image Preprocessing",
+        default=False,
+        help=(
+            "Master toggle for image preprocessing before OCR. When disabled, "
+            "each rendered page is passed to OCR as-is (existing behavior). "
+            "Enable this for low-quality scans (e.g. photocopied passbooks) "
+            "where OCR text comes out too noisy for parser_code to parse."
+        ),
+    )
+    preprocess_grayscale = fields.Boolean(
+        string="Grayscale",
+        default=True,
+        help=(
+            "Convert the rendered page to a single-channel grayscale image "
+            "before further preprocessing steps. Only applied when "
+            "'Enable Image Preprocessing' is active."
+        ),
+    )
+    preprocess_autocontrast = fields.Boolean(
+        string="Auto Contrast",
+        default=True,
+        help=(
+            "Normalize pixel intensity to the full 0-255 range to improve "
+            "contrast on faded or unevenly lit scans. Only applied when "
+            "'Enable Image Preprocessing' is active."
+        ),
+    )
+    preprocess_binarize = fields.Selection(
+        string="Binarization",
+        selection=[
+            ("none", "None"),
+            ("global", "Global threshold"),
+            ("otsu", "Otsu"),
+            ("adaptive", "Adaptive"),
+        ],
+        default="adaptive",
+        help=(
+            "Method used to convert the grayscale image into pure black-and-"
+            "white pixels before OCR. 'Adaptive' is recommended for scans "
+            "with uneven lighting or folds (e.g. passbook photos): "
+            "'None' = skip binarization, "
+            "'Global threshold' = single fixed threshold value ('Threshold' "
+            "field below), "
+            "'Otsu' = automatic single threshold computed from the image "
+            "histogram, "
+            "'Adaptive' = local threshold computed per image region. "
+            "Only applied when 'Enable Image Preprocessing' is active."
+        ),
+    )
+    preprocess_threshold = fields.Integer(
+        string="Threshold",
+        default=128,
+        help=(
+            "Pixel intensity threshold (0-255) used only when 'Binarization' "
+            "is set to 'Global threshold'. Pixels above this value become "
+            "white, pixels at or below become black."
+        ),
+    )
+    preprocess_deskew = fields.Boolean(
+        string="Deskew",
+        default=False,
+        help=(
+            "Automatically detect and correct the rotation angle of a "
+            "slightly tilted scan before OCR. Only applied when "
+            "'Enable Image Preprocessing' is active."
+        ),
+    )
+    preprocess_scale = fields.Float(
+        string="Upscale Factor",
+        default=1.0,
+        help=(
+            "Factor used to resize the rendered page before other "
+            "preprocessing steps, e.g. 2.0 doubles width and height. Values "
+            "greater than 1.0 can help OCR read small text on low-resolution "
+            "scans. Only applied when 'Enable Image Preprocessing' is active."
+        ),
+    )
+
+    def _preprocess_image(self, image):
+        """Apply configured OpenCV preprocessing steps to a rendered page.
+
+        Pure seam for testing: accepts and returns a PIL Image, no OCR or
+        PDF rendering involved.
+        """
+        self.ensure_one()
+        arr = numpy.array(image)
+
+        if self.preprocess_scale and self.preprocess_scale != 1.0:
+            arr = cv2.resize(
+                arr,
+                None,
+                fx=self.preprocess_scale,
+                fy=self.preprocess_scale,
+                interpolation=cv2.INTER_CUBIC,
+            )
+
+        needs_grayscale = (
+            self.preprocess_grayscale or self.preprocess_binarize != "none"
+        )
+        if needs_grayscale and arr.ndim == 3:
+            arr = cv2.cvtColor(arr, cv2.COLOR_RGB2GRAY)
+
+        if self.preprocess_autocontrast:
+            arr = cv2.normalize(arr, None, 0, 255, cv2.NORM_MINMAX)
+
+        if self.preprocess_binarize == "global":
+            _thresh, arr = cv2.threshold(
+                arr, self.preprocess_threshold, 255, cv2.THRESH_BINARY
+            )
+        elif self.preprocess_binarize == "otsu":
+            _thresh, arr = cv2.threshold(
+                arr, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+            )
+        elif self.preprocess_binarize == "adaptive":
+            arr = cv2.adaptiveThreshold(
+                arr,
+                255,
+                cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+                cv2.THRESH_BINARY,
+                31,
+                15,
+            )
+
+        if self.preprocess_deskew:
+            arr = self._preprocess_deskew(arr)
+
+        return Image.fromarray(arr)
+
+    def _preprocess_deskew(self, arr):
+        """Estimate and correct the rotation angle of a binarized image.
+
+        Returns the input array unchanged if no non-zero pixels are found
+        (e.g. a blank page), instead of raising.
+        """
+        inverted = 255 - arr
+        coords = cv2.findNonZero(inverted)
+        if coords is None:
+            return arr
+
+        angle = cv2.minAreaRect(coords)[-1]
+        if angle < -45:
+            angle = 90 + angle
+
+        height, width = arr.shape[:2]
+        center = (width / 2, height / 2)
+        rotation_matrix = cv2.getRotationMatrix2D(center, angle, 1.0)
+        return cv2.warpAffine(
+            arr,
+            rotation_matrix,
+            (width, height),
+            flags=cv2.INTER_CUBIC,
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=255,
+        )
 
     def _extract(self, data_file):
         """Extract OCR text per page from PDF binary data using Tesseract."""
@@ -99,7 +258,9 @@ odoo/custom/dependencies/apt.txt, then rebuild the Odoo image (invoke img_build)
             images = pdf2image.convert_from_bytes(data_file, dpi=self.ocr_dpi)
             pages = [
                 pytesseract.image_to_string(
-                    image, lang=self.ocr_lang, config="--psm %d" % self.ocr_psm
+                    self._preprocess_image(image) if self.preprocess_enabled else image,
+                    lang=self.ocr_lang,
+                    config="--psm %d" % self.ocr_psm,
                 )
                 for image in images
             ]

--- a/ssi_account_statement_import_pdf_image/tests/test_import_pdf_image.py
+++ b/ssi_account_statement_import_pdf_image/tests/test_import_pdf_image.py
@@ -4,6 +4,10 @@
 import base64
 from unittest import mock
 
+import cv2
+import numpy
+from PIL import Image
+
 from odoo.exceptions import AccessError, UserError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
@@ -232,3 +236,165 @@ class TestImportPdfImage(TransactionCase):
                     "parser_code": _EMPTY_PARSER_CODE,
                 }
             )
+
+    @staticmethod
+    def _gradient_image(width=64, height=64):
+        """RGB image with a smooth gradient, used to exercise binarization."""
+        row = numpy.tile(numpy.linspace(0, 255, width, dtype=numpy.uint8), (height, 1))
+        arr = numpy.stack([row, row, row], axis=-1)
+        return Image.fromarray(arr, mode="RGB")
+
+    @staticmethod
+    def _skewed_rect_array(width=200, height=200, angle=12.0):
+        """Binarized-style array (white background, black rectangle 'text')
+        rotated by `angle` degrees — same convention _preprocess_deskew
+        expects as input (dark foreground on light background)."""
+        arr = numpy.full((height, width), 255, dtype=numpy.uint8)
+        arr[80:120, 20:180] = 0
+        center = (width / 2, height / 2)
+        rotation_matrix = cv2.getRotationMatrix2D(center, angle, 1.0)
+        return cv2.warpAffine(
+            arr,
+            rotation_matrix,
+            (width, height),
+            flags=cv2.INTER_CUBIC,
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=255,
+        )
+
+    @staticmethod
+    def _rect_angle(arr):
+        """Skew angle (degrees) of the rectangle in `arr`, normalized so 0
+        means axis-aligned (no skew). `arr` follows the white-background/
+        dark-foreground convention (same as _preprocess_deskew's input)."""
+        inverted = 255 - arr
+        coords = cv2.findNonZero(inverted)
+        if coords is None:
+            return 0.0
+        raw_angle = cv2.minAreaRect(coords)[-1]
+        if raw_angle < -45:
+            return -90 - raw_angle
+        return -raw_angle
+
+    def test_preprocess_grayscale(self):
+        """Grayscale step reduces an RGB image to single-channel 'L' mode."""
+        self.mapping.write(
+            {
+                "preprocess_enabled": True,
+                "preprocess_grayscale": True,
+                "preprocess_autocontrast": False,
+                "preprocess_binarize": "none",
+                "preprocess_deskew": False,
+            }
+        )
+        rgb = self._gradient_image()
+        img = self.mapping._preprocess_image(rgb)
+        self.assertEqual(img.mode, "L")
+
+    def test_preprocess_adaptive_binary(self):
+        """Adaptive binarization yields only pure black/white pixel values."""
+        self.mapping.write(
+            {
+                "preprocess_enabled": True,
+                "preprocess_grayscale": True,
+                "preprocess_autocontrast": False,
+                "preprocess_binarize": "adaptive",
+                "preprocess_deskew": False,
+            }
+        )
+        img = self.mapping._preprocess_image(self._gradient_image())
+        values = set(numpy.array(img).flatten().tolist())
+        self.assertTrue(values.issubset({0, 255}))
+
+    def test_preprocess_otsu_binary(self):
+        """Otsu binarization yields only pure black/white pixel values."""
+        self.mapping.write(
+            {
+                "preprocess_enabled": True,
+                "preprocess_grayscale": True,
+                "preprocess_autocontrast": False,
+                "preprocess_binarize": "otsu",
+                "preprocess_deskew": False,
+            }
+        )
+        img = self.mapping._preprocess_image(self._gradient_image())
+        values = set(numpy.array(img).flatten().tolist())
+        self.assertTrue(values.issubset({0, 255}))
+
+    def test_preprocess_global_threshold_binary(self):
+        """Global threshold binarization yields only pure black/white pixel values."""
+        self.mapping.write(
+            {
+                "preprocess_enabled": True,
+                "preprocess_grayscale": True,
+                "preprocess_autocontrast": False,
+                "preprocess_binarize": "global",
+                "preprocess_threshold": 128,
+                "preprocess_deskew": False,
+            }
+        )
+        img = self.mapping._preprocess_image(self._gradient_image())
+        values = set(numpy.array(img).flatten().tolist())
+        self.assertTrue(values.issubset({0, 255}))
+
+    def test_preprocess_disabled_is_noop_in_extract(self):
+        """_extract never calls _preprocess_image when preprocess_enabled is False."""
+        self.mapping.write({"preprocess_enabled": False})
+        fake_image = self._gradient_image()
+        with mock.patch(
+            "pdf2image.convert_from_bytes", return_value=[fake_image]
+        ), mock.patch(
+            "pytesseract.image_to_string", return_value="OCR TEXT"
+        ), mock.patch.object(
+            type(self.mapping), "_preprocess_image"
+        ) as mocked_preprocess:
+            self.mapping._extract(b"dummy pdf bytes")
+            mocked_preprocess.assert_not_called()
+
+    def test_preprocess_enabled_invoked_in_extract(self):
+        """_extract calls _preprocess_image once per page when enabled."""
+        self.mapping.write({"preprocess_enabled": True})
+        fake_image = self._gradient_image()
+        with mock.patch(
+            "pdf2image.convert_from_bytes", return_value=[fake_image]
+        ), mock.patch(
+            "pytesseract.image_to_string", return_value="OCR TEXT"
+        ), mock.patch.object(
+            type(self.mapping), "_preprocess_image", return_value=fake_image
+        ) as mocked_preprocess:
+            self.mapping._extract(b"dummy pdf bytes")
+            mocked_preprocess.assert_called_once_with(fake_image)
+
+    def test_preprocess_deskew_empty_image_safe(self):
+        """Deskew on a blank image does not raise and returns an Image."""
+        self.mapping.write(
+            {
+                "preprocess_enabled": True,
+                "preprocess_grayscale": True,
+                "preprocess_autocontrast": False,
+                "preprocess_binarize": "none",
+                "preprocess_deskew": True,
+            }
+        )
+        blank = Image.fromarray(numpy.zeros((64, 64), dtype=numpy.uint8), mode="L")
+        img = self.mapping._preprocess_image(blank)
+        self.assertIsInstance(img, Image.Image)
+
+    def test_preprocess_deskew_reduces_angle(self):
+        """Deskew reduces the estimated skew angle of a rotated rectangle."""
+        self.mapping.write(
+            {
+                "preprocess_enabled": True,
+                "preprocess_grayscale": False,
+                "preprocess_autocontrast": False,
+                "preprocess_binarize": "none",
+                "preprocess_deskew": True,
+            }
+        )
+        before = self._skewed_rect_array(angle=12.0)
+        angle_before = self._rect_angle(before)
+
+        after_img = self.mapping._preprocess_image(Image.fromarray(before, mode="L"))
+        angle_after = self._rect_angle(numpy.array(after_img))
+
+        self.assertLess(abs(angle_after), abs(angle_before))

--- a/ssi_account_statement_import_pdf_image/views/account_statement_import_pdf_image_mapping_views.xml
+++ b/ssi_account_statement_import_pdf_image/views/account_statement_import_pdf_image_mapping_views.xml
@@ -59,6 +59,34 @@
                         <field name="ocr_psm" />
                         <field name="currency_id" />
                     </group>
+                    <separator string="Image Preprocessing" />
+                    <group>
+                        <field name="preprocess_enabled" />
+                        <field
+                                name="preprocess_grayscale"
+                                attrs="{'invisible': [('preprocess_enabled', '=', False)]}"
+                            />
+                        <field
+                                name="preprocess_autocontrast"
+                                attrs="{'invisible': [('preprocess_enabled', '=', False)]}"
+                            />
+                        <field
+                                name="preprocess_binarize"
+                                attrs="{'invisible': [('preprocess_enabled', '=', False)]}"
+                            />
+                        <field
+                                name="preprocess_threshold"
+                                attrs="{'invisible': ['|', ('preprocess_enabled', '=', False), ('preprocess_binarize', '!=', 'global')]}"
+                            />
+                        <field
+                                name="preprocess_deskew"
+                                attrs="{'invisible': [('preprocess_enabled', '=', False)]}"
+                            />
+                        <field
+                                name="preprocess_scale"
+                                attrs="{'invisible': [('preprocess_enabled', '=', False)]}"
+                            />
+                    </group>
                     <separator string="Parser Code" />
                     <field name="parser_code" nolabel="1" widget="text" />
                 </page>


### PR DESCRIPTION
## Ringkasan

Menambahkan tahap preprocessing gambar berbasis OpenCV sebelum OCR di
`account.statement.import.pdf.image.mapping`, configurable per record mapping
dan backward-compatible (default `preprocess_enabled=False`).

* Field baru: `preprocess_enabled`, `preprocess_grayscale`,
  `preprocess_autocontrast`, `preprocess_binarize` (global/otsu/adaptive),
  `preprocess_threshold`, `preprocess_deskew`, `preprocess_scale`.
* Method seam `_preprocess_image` (OpenCV + numpy), dipanggil di `_extract`
  hanya saat `preprocess_enabled=True`.
* `cv2` dan `numpy` ditambahkan sebagai `external_dependencies["python"]`
  wajib (pip: `opencv-python-headless`).
* Unit test baru untuk seam preprocessing + integrasi ke `_extract`
  (16/16 test lolos lokal).

Ref: BL-0014 (backlog `odoo-development-backlog`).