### PR TITLE
[FIX] ssi_account_statement_import_mutasi_ai

### DIFF
--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import.py
@@ -86,9 +86,15 @@ class AccountStatementImport(models.TransientModel):
     def _prepare_mutasi_ai_job(self, attachment):
         self.ensure_one()
         journal_id = self.env.context.get("journal_id")
+        statement_id = False
+        if self.env.context.get("active_model") == "account.bank.statement":
+            active_ids = self.env.context.get("active_ids") or []
+            if active_ids:
+                statement_id = active_ids[0]
         return {
             "attachment_id": attachment.id,
             "statement_filename": self.statement_filename,
             "journal_id": journal_id,
+            "statement_id": statement_id,
             "backend_id": self.mutasi_ai_backend_id.id,
         }

--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -59,6 +59,15 @@ class AccountStatementImportMutasiAiJob(models.Model):
         "attached to; when empty, the journal is resolved from the "
         "account number returned by mutasi-ai.",
     )
+    statement_id = fields.Many2one(
+        string="Target Statement",
+        comodel_name="account.bank.statement",
+        readonly=True,
+        help="Existing bank statement the import was launched from (e.g. "
+        "via its 'Import Statement' button), if any. When set, the "
+        "extracted transactions are added to this statement instead of "
+        "creating a new one.",
+    )
     backend_id = fields.Many2one(
         string="Mutasi AI Backend",
         comodel_name="account.statement.import.mutasi.ai.backend",
@@ -207,6 +216,13 @@ Solution: Wait for the current job to finish, or check its result
             import_context = {}
             if self.journal_id:
                 import_context["journal_id"] = self.journal_id.id
+            if self.statement_id:
+                # Mirrors the context the base wizard normally receives when
+                # opened from an existing statement's "Import Statement"
+                # button, so `import_single_statement` updates it instead
+                # of creating a new one.
+                import_context["active_model"] = "account.bank.statement"
+                import_context["active_ids"] = [self.statement_id.id]
             wizard = (
                 self.env["account.statement.import"]
                 .sudo()

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -170,6 +170,42 @@ class TestImportMutasiAi(TransactionCase):
         )
         self.assertEqual(len(lines), 2)
 
+    def test_run_with_statement_id_updates_existing_statement(self):
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        existing_statement = self.env["account.bank.statement"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "date": "2026-01-31",
+            }
+        )
+        statement_count_before = self.env["account.bank.statement"].search_count([])
+        job = self._make_job(unique_suffix="update")
+        job.write({"statement_id": existing_statement.id})
+        with patch(
+            _CALL_SERVICE_PATH,
+            return_value=_sample_response(
+                unique_suffix="update", currency_code=self.company_currency
+            ),
+        ):
+            job._run()
+        self.assertEqual(job.state, "done")
+        self.assertEqual(
+            job.statement_ids,
+            existing_statement,
+            "job must report the existing statement it updated, not a new one",
+        )
+        statement_count_after = self.env["account.bank.statement"].search_count([])
+        self.assertEqual(
+            statement_count_before,
+            statement_count_after,
+            "importing into an existing statement must not create a new statement",
+        )
+        lines = self.env["account.bank.statement.line"].search(
+            [("statement_id", "=", existing_statement.id)]
+        )
+        self.assertEqual(len(lines), 2)
+
     def test_run_dedup_second_run_need_review(self):
         if not self.bank_journal:
             self.skipTest("No bank journal found in test environment")
@@ -249,6 +285,53 @@ class TestImportMutasiAi(TransactionCase):
             statement_count_after,
             "enqueue path must not create a statement synchronously",
         )
+
+    def test_enqueue_from_existing_statement_captures_statement_id(self):
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        existing_statement = self.env["account.bank.statement"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "date": "2026-01-31",
+            }
+        )
+        wizard = (
+            self.env["account.statement.import"]
+            .with_context(
+                active_model="account.bank.statement",
+                active_ids=[existing_statement.id],
+            )
+            .create(
+                {
+                    "statement_file": base64.b64encode(b"dummy pdf content"),
+                    "statement_filename": "enqueue_from_statement_test.pdf",
+                    "mutasi_ai_backend_id": self.backend.id,
+                }
+            )
+        )
+        wizard.import_file_button()
+
+        job = self.env[_JOB_MODEL].search(
+            [("statement_filename", "=", "enqueue_from_statement_test.pdf")]
+        )
+        self.assertEqual(len(job), 1)
+        self.assertEqual(job.statement_id, existing_statement)
+
+    def test_enqueue_without_active_statement_leaves_statement_id_empty(self):
+        wizard = self.env["account.statement.import"].create(
+            {
+                "statement_file": base64.b64encode(b"dummy pdf content"),
+                "statement_filename": "enqueue_no_statement_test.pdf",
+                "mutasi_ai_backend_id": self.backend.id,
+            }
+        )
+        wizard.import_file_button()
+
+        job = self.env[_JOB_MODEL].search(
+            [("statement_filename", "=", "enqueue_no_statement_test.pdf")]
+        )
+        self.assertEqual(len(job), 1)
+        self.assertFalse(job.statement_id)
 
     def test_preselect_backend_from_journal_default(self):
         if not self.bank_journal:

--- a/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
+++ b/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
@@ -88,6 +88,7 @@
                         <field name="name" />
                         <field name="statement_filename" />
                         <field name="journal_id" />
+                        <field name="statement_id" />
                         <field name="backend_id" />
                     </group>
                     <group>


### PR DESCRIPTION
## Ringkasan

Perbaikan bug: import mutasi-ai selalu membuat bank statement baru meskipun
wizard dijalankan dari tombol Import pada bank statement yang sudah ada.

**Root cause:** job diproses secara asynchronous via `queue_job`. Wizard dasar
(`ssi_account_statement_import`) memutuskan update vs create berdasarkan
context `active_model`/`active_ids` (lihat `import_single_statement`), tapi
context ini hanya tersedia pada request sinkron saat wizard pertama kali
disubmit. Saat job dieksekusi belakangan (`_run()`), hanya `journal_id` yang
dibawa ke wizard baru — `active_model`/`active_ids` hilang, sehingga selalu
jatuh ke jalur `_create_bank_statements` (create), bukan
`_update_bank_statements` (update).

**Perbaikan:**
* Tambah field `statement_id` pada `account.statement.import.mutasi.ai.job` —
  menyimpan bank statement asal saat wizard di-enqueue (diambil dari context
  `active_model == 'account.bank.statement'` + `active_ids`).
* `_run()` kini mengirim ulang context `active_model`/`active_ids` ke wizard
  sinkron sesuai `statement_id` yang tersimpan, sehingga
  `import_single_statement` memanggil `_update_bank_statements` alih-alih
  `_create_bank_statements` saat `statement_id` terisi.
* Tambah field `statement_id` di form job.
* Tambah unit test: enqueue dari statement yang ada menangkap `statement_id`,
  dan `_run()` dengan `statement_id` memperbarui statement yang sama tanpa
  membuat statement baru.

Perbaikan diverifikasi manual via `odoo shell` sebelum commit (rollback):
capture `statement_id` saat enqueue, lalu `_run()` menghasilkan job dengan
`statement_ids` = statement yang sama (bukan baru), jumlah bank statement
tidak bertambah, dan 2 baris transaksi masuk ke statement yang sudah ada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)