### PR TITLE
[UPD] ssi_account_statement_import_mutasi_ai

### DIFF
--- a/ssi_account_statement_import_mutasi_ai/README.rst
+++ b/ssi_account_statement_import_mutasi_ai/README.rst
@@ -10,8 +10,9 @@ Import bank statements using the mutasi-ai AI extraction service. Each
 mutasi-ai backend holds the service's base URL and bearer token. Files
 uploaded through the standard Import Statement wizard are queued via
 ``queue_job`` and processed in the background, since a single extraction
-can take several minutes. Progress, errors, and links to the resulting
-bank statements can be monitored from the Mutasi AI Import Jobs menu.
+can take several minutes. Progress, errors, and the resulting
+transactions can be monitored from the related bank statement, which
+lists its Mutasi AI import jobs in a read-only tab.
 
 
 Bug Tracker

--- a/ssi_account_statement_import_mutasi_ai/__manifest__.py
+++ b/ssi_account_statement_import_mutasi_ai/__manifest__.py
@@ -29,6 +29,7 @@
         "views/account_statement_import_mutasi_ai_job_views.xml",
         "views/account_statement_import_views.xml",
         "views/account_journal_views.xml",
+        "views/account_bank_statement_views.xml",
     ],
     "installable": True,
     "application": False,

--- a/ssi_account_statement_import_mutasi_ai/models/__init__.py
+++ b/ssi_account_statement_import_mutasi_ai/models/__init__.py
@@ -5,3 +5,4 @@ from . import account_statement_import_mutasi_ai_backend
 from . import account_statement_import_mutasi_ai_job
 from . import account_statement_import
 from . import account_journal
+from . import account_bank_statement

--- a/ssi_account_statement_import_mutasi_ai/models/account_bank_statement.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_bank_statement.py
@@ -1,0 +1,20 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class AccountBankStatement(models.Model):
+    _inherit = "account.bank.statement"
+
+    mutasi_ai_job_ids = fields.Many2many(
+        string="Mutasi AI Import Jobs",
+        comodel_name="account.statement.import.mutasi.ai.job",
+        relation="account_statement_import_mutasi_ai_job_statement_rel",
+        column1="statement_id",
+        column2="job_id",
+        readonly=True,
+        help="Mutasi AI extraction job(s) whose imported transactions "
+        "landed on this bank statement. Read-only; jobs are created and "
+        "processed from the bank statement import wizard.",
+    )

--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import.py
@@ -66,12 +66,14 @@ class AccountStatementImport(models.TransientModel):
             "params": {
                 "title": _("Mutasi AI"),
                 "message": _(
-                    "Bank statement '%s' queued for AI extraction. You can "
-                    "follow its progress in the Mutasi AI Import Jobs menu."
+                    "Bank statement '%s' queued for AI extraction. It is "
+                    "processed in the background; you can follow its progress "
+                    "from the related bank statement."
                 )
                 % (self.statement_filename or ""),
-                "type": "info",
+                "type": "success",
                 "sticky": False,
+                "next": {"type": "ir.actions.act_window_close"},
             },
         }
 

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -205,6 +205,31 @@ class TestImportMutasiAi(TransactionCase):
             [("statement_id", "=", existing_statement.id)]
         )
         self.assertEqual(len(lines), 2)
+        self.assertIn(
+            job,
+            existing_statement.mutasi_ai_job_ids,
+            "the updated bank statement must expose the import job "
+            "via mutasi_ai_job_ids",
+        )
+
+    def test_run_links_job_to_created_statement(self):
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        job = self._make_job(unique_suffix="link")
+        with patch(
+            _CALL_SERVICE_PATH,
+            return_value=_sample_response(
+                unique_suffix="link", currency_code=self.company_currency
+            ),
+        ):
+            job._run()
+        self.assertTrue(job.statement_ids)
+        self.assertIn(
+            job,
+            job.statement_ids.mutasi_ai_job_ids,
+            "the created bank statement must expose its import job "
+            "via mutasi_ai_job_ids",
+        )
 
     def test_run_dedup_second_run_need_review(self):
         if not self.bank_journal:
@@ -284,6 +309,23 @@ class TestImportMutasiAi(TransactionCase):
             statement_count_before,
             statement_count_after,
             "enqueue path must not create a statement synchronously",
+        )
+
+    def test_enqueue_returns_close_action(self):
+        wizard = self.env["account.statement.import"].create(
+            {
+                "statement_file": base64.b64encode(b"dummy pdf content"),
+                "statement_filename": "close_action_test.pdf",
+                "mutasi_ai_backend_id": self.backend.id,
+            }
+        )
+        action = wizard.import_file_button()
+        self.assertEqual(action["tag"], "display_notification")
+        self.assertEqual(action["params"]["type"], "success")
+        self.assertEqual(
+            action["params"]["next"]["type"],
+            "ir.actions.act_window_close",
+            "the import wizard must close after a successful enqueue",
         )
 
     def test_enqueue_from_existing_statement_captures_statement_id(self):

--- a/ssi_account_statement_import_mutasi_ai/views/account_bank_statement_views.xml
+++ b/ssi_account_statement_import_mutasi_ai/views/account_bank_statement_views.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="account_bank_statement_mutasi_ai_job_form" model="ir.ui.view">
+    <field name="name">account.bank.statement.mutasi.ai.job.form</field>
+    <field name="model">account.bank.statement</field>
+    <field name="inherit_id" ref="account.view_bank_statement_form" />
+    <field name="arch" type="xml">
+        <xpath expr="//notebook" position="inside">
+            <page
+                    name="mutasi_ai_jobs"
+                    string="Mutasi AI Import Jobs"
+                    attrs="{'invisible': [('mutasi_ai_job_ids', '=', [])]}"
+                >
+                <field name="mutasi_ai_job_ids" readonly="1">
+                    <tree
+                            decoration-danger="state == 'failed'"
+                            decoration-warning="state == 'need_review'"
+                            decoration-success="state == 'done'"
+                            decoration-muted="state in ('draft', 'queued')"
+                        >
+                        <field name="name" />
+                        <field name="statement_filename" />
+                        <field name="backend_id" />
+                        <field name="external_status" optional="hide" />
+                        <field name="state" widget="badge" />
+                        <field name="create_date" optional="show" />
+                    </tree>
+                </field>
+            </page>
+        </xpath>
+    </field>
+</record>
+</odoo>

--- a/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
+++ b/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
@@ -3,42 +3,6 @@
      Copyright 2026 PT. Simetri Sinergi Indonesia
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-<record id="account_statement_import_mutasi_ai_job_view_search" model="ir.ui.view">
-    <field name="name">account.statement.import.mutasi.ai.job - search</field>
-    <field name="model">account.statement.import.mutasi.ai.job</field>
-    <field name="arch" type="xml">
-        <search>
-            <field name="name" />
-            <field name="statement_filename" />
-            <field name="journal_id" />
-            <field name="backend_id" />
-            <filter
-                    name="dom_failed"
-                    string="Failed"
-                    domain="[('state', '=', 'failed')]"
-                />
-            <filter
-                    name="dom_need_review"
-                    string="Need Review"
-                    domain="[('state', '=', 'need_review')]"
-                />
-            <filter name="dom_done" string="Done" domain="[('state', '=', 'done')]" />
-            <group name="group_by">
-                <filter
-                        name="grp_state"
-                        string="Status"
-                        context="{'group_by': 'state'}"
-                    />
-                <filter
-                        name="grp_journal"
-                        string="Journal"
-                        context="{'group_by': 'journal_id'}"
-                    />
-            </group>
-        </search>
-    </field>
-</record>
-
 <record id="account_statement_import_mutasi_ai_job_view_tree" model="ir.ui.view">
     <field name="name">account.statement.import.mutasi.ai.job - tree</field>
     <field name="model">account.statement.import.mutasi.ai.job</field>
@@ -109,22 +73,4 @@
         </form>
     </field>
 </record>
-
-<record
-        id="account_statement_import_mutasi_ai_job_action"
-        model="ir.actions.act_window"
-    >
-    <field name="name">Mutasi AI Import Jobs</field>
-    <field name="type">ir.actions.act_window</field>
-    <field name="res_model">account.statement.import.mutasi.ai.job</field>
-    <field name="view_mode">tree,form</field>
-</record>
-
-<menuitem
-        id="menu_account_statement_import_mutasi_ai_job"
-        name="Mutasi AI Import Jobs"
-        parent="ssi_financial_accounting.menu_bank_cash"
-        action="account_statement_import_mutasi_ai_job_action"
-        sequence="3"
-    />
 </odoo>


### PR DESCRIPTION
## Ringkasan

Revisi modul **ssi_account_statement_import_mutasi_ai**:

* **Tutup wizard otomatis** setelah job AI berhasil di-enqueue — notifikasi sukses kini disertai `ir.actions.act_window_close`, sehingga dialog import langsung tertutup.
* **Hapus menu "Mutasi AI Import Jobs"** beserta `act_window` dan search view-nya.
* **Tampilkan job import sebagai daftar read-only** pada bank statement: field Many2many `mutasi_ai_job_ids` (memakai relation table `statement_ids` yang sudah ada, kolom dibalik) ditampilkan pada tab read-only di form bank statement. Tab disembunyikan bila kosong.
* Sesuaikan README dan tambah unit test (wizard close action + keterhubungan job ↔ bank statement).

Tidak ada field/method/model yang di-rename.