### PR TITLE
[UPD] ssi_financial_accounting_operating_unit

### DIFF
--- a/ssi_financial_accounting_operating_unit/__manifest__.py
+++ b/ssi_financial_accounting_operating_unit/__manifest__.py
@@ -12,10 +12,12 @@
     "depends": [
         "ssi_financial_accounting",
         "ssi_operating_unit_mixin",
+        "account_statement_import",
     ],
     "data": [
         "security/res_group/journal_entry.xml",
         "security/res_group/bank_statement.xml",
+        "security/res_group/account_payment.xml",
         "security/ir_rule/account_journal.xml",
         "security/ir_rule/account_move.xml",
         "security/ir_rule/account_move_line.xml",

--- a/ssi_financial_accounting_operating_unit/models/account_move.py
+++ b/ssi_financial_accounting_operating_unit/models/account_move.py
@@ -2,7 +2,7 @@
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -12,6 +12,11 @@ class AccountMove(models.Model):
         "account.move",
         "mixin.single_operating_unit",
     ]
+
+    operating_unit_id = fields.Many2one(
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
 
     @api.onchange("invoice_line_ids")
     def _onchange_invoice_line_ids(self):
@@ -27,16 +32,20 @@ class AccountMove(models.Model):
             not self.journal_id
             or self.operating_unit_id not in self.journal_id.operating_unit_ids
         ):
-            journal = self.env["account.journal"].search(
-                [("type", "=", self.journal_id.type)]
-            )
-            jf = journal.filtered(
-                lambda aj: self.operating_unit_id in aj.operating_unit_ids
-            )
-            if not jf:
-                self.journal_id = journal[0]
-            else:
-                self.journal_id = jf[0]
+            # self.journal_id may be empty (e.g. new move not yet linked to a
+            # journal) — searching with type=False would return an empty
+            # recordset and journal[0] below would raise IndexError. Only
+            # look for a replacement journal when there is a current one to
+            # match against.
+            if self.journal_id:
+                journal = self.env["account.journal"].search(
+                    [("type", "=", self.journal_id.type)]
+                )
+                if journal:
+                    jf = journal.filtered(
+                        lambda aj: self.operating_unit_id in aj.operating_unit_ids
+                    )
+                    self.journal_id = jf[0] if jf else journal[0]
             for line in self.line_ids:
                 line.operating_unit_id = self.operating_unit_id
 

--- a/ssi_financial_accounting_operating_unit/security/ir_rule/account_bank_statement.xml
+++ b/ssi_financial_accounting_operating_unit/security/ir_rule/account_bank_statement.xml
@@ -7,7 +7,8 @@
     <field name="model_id" ref="account.model_account_bank_statement" />
     <field name="groups" eval="[(4, ref('bank_statement_ou_group'))]" />
     <field name="domain_force">
-        [('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
+        ['|', ('operating_unit_id','=',False),
+        ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
     </field>
     <field name="name">account.bank.statement - ou</field>
     <field eval="1" name="perm_unlink" />

--- a/ssi_financial_accounting_operating_unit/security/ir_rule/account_move.xml
+++ b/ssi_financial_accounting_operating_unit/security/ir_rule/account_move.xml
@@ -7,7 +7,8 @@
     <field name="model_id" ref="account.model_account_move" />
     <field name="groups" eval="[(4, ref('journal_entry_ou_group'))]" />
     <field name="domain_force">
-        [('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
+        ['|', ('operating_unit_id','=',False),
+        ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
     </field>
     <field name="name">account.move - ou</field>
     <field eval="1" name="perm_unlink" />

--- a/ssi_financial_accounting_operating_unit/security/ir_rule/account_move_line.xml
+++ b/ssi_financial_accounting_operating_unit/security/ir_rule/account_move_line.xml
@@ -7,7 +7,8 @@
     <field name="model_id" ref="account.model_account_move_line" />
     <field name="groups" eval="[(4, ref('journal_entry_ou_group'))]" />
     <field name="domain_force">
-        [('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
+        ['|', ('operating_unit_id','=',False),
+        ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
     </field>
     <field name="name">account.move.line - ou</field>
     <field eval="1" name="perm_unlink" />

--- a/ssi_financial_accounting_operating_unit/security/ir_rule/account_payment.xml
+++ b/ssi_financial_accounting_operating_unit/security/ir_rule/account_payment.xml
@@ -5,9 +5,13 @@
 <odoo>
 <record id="account_payment_rule_ou" model="ir.rule">
     <field name="model_id" ref="account.model_account_payment" />
-    <field name="groups" eval="[(4, ref('journal_entry_ou_group'))]" />
+    <field
+            name="groups"
+            eval="[(4, ref('customer_payment_ou_group')), (4, ref('vendor_payment_ou_group'))]"
+        />
     <field name="domain_force">
-        [('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
+        ['|', ('operating_unit_id','=',False),
+        ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
     </field>
     <field name="name">account.payment - ou</field>
     <field eval="1" name="perm_unlink" />

--- a/ssi_financial_accounting_operating_unit/security/res_group/account_payment.xml
+++ b/ssi_financial_accounting_operating_unit/security/res_group/account_payment.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="customer_payment_ou_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_financial_accounting.customer_payment_data_ownership_module_category"
+        />
+</record>
+
+<record id="ssi_financial_accounting.customer_payment_company_group" model="res.groups">
+    <field name="implied_ids" eval="[(4, ref('customer_payment_ou_group'))]" />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+</record>
+
+<record id="vendor_payment_ou_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_financial_accounting.vendor_payment_data_ownership_module_category"
+        />
+</record>
+
+<record id="ssi_financial_accounting.vendor_payment_company_group" model="res.groups">
+    <field name="implied_ids" eval="[(4, ref('vendor_payment_ou_group'))]" />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+</record>
+</odoo>

--- a/ssi_financial_accounting_operating_unit/tests/test_data_ssi_financial_accounting_operating_unit.yaml
+++ b/ssi_financial_accounting_operating_unit/tests/test_data_ssi_financial_accounting_operating_unit.yaml
@@ -1,0 +1,86 @@
+scenarios:
+  - name: "Create account move without operating unit stays draft"
+    steps:
+      - step: "Create general journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "journal"
+        values:
+          name: "Test General Journal OU"
+          code: "TSTGOU"
+          type: "general"
+
+      - step: "Create move without operating unit"
+        action: "create"
+        model: "account.move"
+        save_as: "move"
+        values:
+          move_type: "entry"
+          journal_id: "EVAL: registry['journal'].id"
+          operating_unit_id: false
+
+      - step: "Assert move is draft and has no operating unit"
+        action: "assert"
+        target: "move"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+          operating_unit_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Bank statement line inherits operating unit from parent statement"
+    steps:
+      - step: "Create partner for operating unit"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Test OU Partner (YAML)"
+
+      - step: "Create operating unit"
+        action: "create"
+        model: "operating.unit"
+        save_as: "ou"
+        values:
+          name: "Test OU (YAML)"
+          code: "TESTOUY"
+          partner_id: "EVAL: registry['partner'].id"
+
+      - step: "Create bank journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "bank_journal"
+        values:
+          name: "Test Bank Journal (YAML)"
+          code: "TSTBKY"
+          type: "bank"
+
+      - step: "Create bank statement with operating unit"
+        action: "create"
+        model: "account.bank.statement"
+        save_as: "statement"
+        values:
+          name: "Test Statement (YAML)"
+          journal_id: "EVAL: registry['bank_journal'].id"
+          operating_unit_id: "EVAL: registry['ou'].id"
+
+      - step: "Create bank statement line"
+        action: "create"
+        model: "account.bank.statement.line"
+        save_as: "line"
+        values:
+          statement_id: "EVAL: registry['statement'].id"
+          payment_ref: "Test Line (YAML)"
+          amount: 100.0
+          date: 2026-07-06
+
+      - step: "Verify line inherited the statement operating unit"
+        action: "search"
+        model: "account.bank.statement.line"
+        domain:
+          - ["id", "=", "EVAL: registry['line'].id"]
+          - ["operating_unit_id", "=", "EVAL: registry['ou'].id"]
+        save_as: "matched"
+        expect_count: 1

--- a/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
+++ b/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
@@ -36,7 +36,14 @@ class TestSsiFinancialAccountingOperatingUnit(YamlTransactionCase):
         )
 
     def _create_ou_scoped_user(self, login, group_xmlids, operating_units):
-        group_ids = [self.env.ref("base.group_user").id]
+        # account.group_account_readonly grants the base ACL (ir.model.access)
+        # to read account.move/account.bank.statement/account.payment; without
+        # it the OU-scoped group alone only affects the ir.rule (row-level)
+        # layer and every read is rejected before the rule is even evaluated.
+        group_ids = [
+            self.env.ref("base.group_user").id,
+            self.env.ref("account.group_account_readonly").id,
+        ]
         for xmlid in group_xmlids:
             group_ids.append(self.env.ref(xmlid).id)
         return self.env["res.users"].create(

--- a/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
+++ b/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
@@ -2,64 +2,62 @@
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields
-from odoo.tests import TransactionCase, tagged
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.exceptions import UserError
+from odoo.tests import Form, tagged
+
+# Most scenarios below are plain Python (not YAML) because the odoo-yaml-test
+# DSL has no primitive for the two things most of them need: asserting that a
+# step raises an exception (ir.rule/constraint checks), and running an action
+# as a dynamically-created user (`as_user` only accepts a fixed XML ID via
+# env.ref, not a record created at runtime). Only the two scenarios that are
+# pure CRUD/state assertions live in the YAML file.
 
 
 @tagged("post_install", "-at_install")
-class TestSsiFinancialAccountingOperatingUnit(TransactionCase):
+class TestSsiFinancialAccountingOperatingUnit(YamlTransactionCase):
     def setUp(self):
         super().setUp()
         self.company = self.env.company
-        self.operating_unit = self.env["operating.unit"].search(
-            [("company_id", "=", self.company.id)],
-            limit=1,
+        self.operating_unit = self._create_operating_unit(
+            "Test Main Operating Unit", "TESTMAINOU"
         )
 
-    def test_account_journal_has_operating_unit_ids(self):
-        """Test that account.journal has operating_unit_ids field."""
-        journal = self.env["account.journal"].search([], limit=1)
-        if not journal:
-            self.skipTest("No journals found")
-        fields_info = journal.fields_get(["operating_unit_ids"])
-        self.assertIn("operating_unit_ids", fields_info)
-
-    def test_account_move_has_operating_unit_id(self):
-        """Test that account.move has operating_unit_id field."""
-        move = self.env["account.move"].search([], limit=1)
-        if not move:
-            self.skipTest("No account moves found")
-        fields_info = move.fields_get(["operating_unit_id"])
-        self.assertIn("operating_unit_id", fields_info)
-
-    def test_account_move_line_has_operating_unit_id(self):
-        """Test that account.move.line has operating_unit_id field."""
-        move_line = self.env["account.move.line"].search([], limit=1)
-        if not move_line:
-            self.skipTest("No move lines found")
-        fields_info = move_line.fields_get(["operating_unit_id"])
-        self.assertIn("operating_unit_id", fields_info)
-
-    def test_account_bank_statement_has_operating_unit_id(self):
-        """Test that account.bank.statement has operating_unit_id field."""
-        model = self.env["account.bank.statement"]
-        fields_info = model.fields_get(["operating_unit_id"])
-        self.assertIn("operating_unit_id", fields_info)
-
-    def test_create_move_without_ou(self):
-        """Test creating account move without operating unit works."""
-        journal = self.env["account.journal"].search(
-            [("type", "=", "general")], limit=1
-        )
-        if not journal:
-            self.skipTest("No general journal found")
-        move = self.env["account.move"].create(
+    def _create_operating_unit(self, name, code):
+        partner = self.env["res.partner"].create({"name": "%s Partner" % name})
+        return self.env["operating.unit"].create(
             {
-                "move_type": "entry",
-                "journal_id": journal.id,
+                "name": name,
+                "code": code,
+                "partner_id": partner.id,
+                "company_id": self.company.id,
             }
         )
-        self.assertEqual(move.state, "draft")
+
+    def _create_ou_scoped_user(self, login, group_xmlids, operating_units):
+        group_ids = [self.env.ref("base.group_user").id]
+        for xmlid in group_xmlids:
+            group_ids.append(self.env.ref(xmlid).id)
+        return self.env["res.users"].create(
+            {
+                "name": login,
+                "login": login,
+                "email": "%s@example.com" % login,
+                "company_id": self.company.id,
+                "company_ids": [(6, 0, [self.company.id])],
+                "groups_id": [(6, 0, group_ids)],
+                "assigned_operating_unit_ids": [(6, 0, operating_units.ids)],
+            }
+        )
+
+    def test_ssi_financial_accounting_operating_unit(self):
+        self.run_yaml_scenario("test_data_ssi_financial_accounting_operating_unit.yaml")
+
+    # ------------------------------------------------------------------
+    # Delegation regressions (_inherits to account.move) — introspection,
+    # not expressible as a YAML create/assert scenario.
+    # ------------------------------------------------------------------
 
     def test_bank_statement_line_ou_via_delegation_not_mixin(self):
         """Regression: account.bank.statement.line gets operating_unit_id via
@@ -69,53 +67,16 @@ class TestSsiFinancialAccountingOperatingUnit(TransactionCase):
         """
         model = self.env["account.bank.statement.line"]
 
-        # Field must exist (via delegation from account.move)
         fields_info = model.fields_get(["operating_unit_id"])
         self.assertIn("operating_unit_id", fields_info)
 
-        # The field originates from account.move via _inherits delegation,
-        # so it must NOT be declared as a local field on the model itself.
         local_fields = model._fields
         local_field = local_fields.get("operating_unit_id")
-        # A delegated field has model_name pointing to the delegated model
         self.assertEqual(
             local_field.related_field.model_name if local_field else None,
             "account.move",
             "operating_unit_id on account.bank.statement.line must be a "
             "delegation field originating from account.move, not a mixin field.",
-        )
-
-    def test_bank_statement_line_ou_propagated_from_statement(self):
-        """Regression: creating a bank.statement.line should carry the OU of the
-        parent bank.statement when OU is set on the statement.
-        """
-        journal = self.env["account.journal"].search([("type", "=", "bank")], limit=1)
-        if not journal or not self.operating_unit:
-            self.skipTest("No bank journal or operating unit found")
-
-        statement = self.env["account.bank.statement"].create(
-            {
-                "name": "Test OU Propagation",
-                "journal_id": journal.id,
-                "operating_unit_id": self.operating_unit.id,
-            }
-        )
-        self.assertEqual(statement.operating_unit_id, self.operating_unit)
-
-        line = self.env["account.bank.statement.line"].create(
-            {
-                "statement_id": statement.id,
-                "payment_ref": "Test Line OU",
-                "amount": 100.0,
-                "date": fields.Date.today(),
-            }
-        )
-        self.assertEqual(
-            line.operating_unit_id,
-            self.operating_unit,
-            "bank.statement.line.operating_unit_id must equal the parent "
-            "statement's operating_unit_id (propagated via create() override, "
-            "stored on account.move via delegation).",
         )
 
     def test_account_payment_ou_via_delegation(self):
@@ -137,12 +98,16 @@ class TestSsiFinancialAccountingOperatingUnit(TransactionCase):
             "field originating from account.move, not a mixin field.",
         )
 
-        journal = self.env["account.journal"].search(
-            [("type", "in", ("bank", "cash"))], limit=1
+        journal = self.env["account.journal"].create(
+            {
+                "name": "Test Payment Delegation Journal",
+                "code": "TSTPAYDJ",
+                "type": "bank",
+            }
         )
-        partner = self.env["res.partner"].search([], limit=1)
-        if not journal or not partner or not self.operating_unit:
-            self.skipTest("No journal/partner/operating unit found")
+        partner = self.env["res.partner"].create(
+            {"name": "Test Payment Delegation Partner"}
+        )
 
         payment = self.env["account.payment"].create(
             {
@@ -163,3 +128,345 @@ class TestSsiFinancialAccountingOperatingUnit(TransactionCase):
             self.operating_unit,
             "account.payment.operating_unit_id must delegate to move_id.",
         )
+
+    # ------------------------------------------------------------------
+    # BL-0043 — readonly after post + onchange IndexError guard.
+    # ------------------------------------------------------------------
+
+    def test_move_operating_unit_id_readonly_after_post(self):
+        """operating_unit_id must stay editable while draft, and become
+        readonly once the move is posted."""
+        ou_a = self._create_operating_unit("Test Readonly OU A", "TESTROA")
+        ou_b = self._create_operating_unit("Test Readonly OU B", "TESTROB")
+        journal = self.env["account.journal"].create(
+            {"name": "Test Readonly Journal", "code": "TSTROJ", "type": "general"}
+        )
+        account_1 = self.env["account.account"].search([], limit=1)
+        account_2 = self.env["account.account"].search(
+            [("id", "!=", account_1.id)], limit=1
+        )
+        move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": journal.id,
+                "operating_unit_id": ou_a.id,
+                "line_ids": [
+                    (0, 0, {"account_id": account_1.id, "debit": 100.0, "credit": 0.0}),
+                    (0, 0, {"account_id": account_2.id, "debit": 0.0, "credit": 100.0}),
+                ],
+            }
+        )
+
+        draft_form = Form(move)
+        draft_form.operating_unit_id = ou_b  # draft: must not raise
+
+        move.action_post()
+        posted_form = Form(move)
+        with self.assertRaises(AssertionError):
+            posted_form.operating_unit_id = ou_a
+
+    def test_onchange_operating_unit_without_journal_no_indexerror(self):
+        """BL-0043 regression: previously `journal[0]` on an empty search
+        result raised IndexError when operating_unit_id was set on a move
+        without a journal_id yet. Invoked directly (not via Form) because
+        Form's own default-journal computation would mask the empty
+        journal_id condition this regression targets."""
+        ou_a = self._create_operating_unit("Test Guard OU A", "TESTGUARDA")
+        move = self.env["account.move"].new({"move_type": "entry"})
+        move.journal_id = False
+        move.operating_unit_id = ou_a
+        move._onchange_operating_unit()  # must not raise IndexError
+        self.assertFalse(move.journal_id)
+
+    def test_onchange_operating_unit_selects_matching_journal(self):
+        """Existing behavior preserved by the BL-0043 guard: setting
+        operating_unit_id auto-selects a journal restricted to that OU."""
+        ou_a = self._create_operating_unit("Test Onchange OU A", "TESTONCA")
+        ou_b = self._create_operating_unit("Test Onchange OU B", "TESTONCB")
+        journal_b = self.env["account.journal"].create(
+            {
+                "name": "Test Onchange Journal B",
+                "code": "TSTONCJB",
+                "type": "general",
+                "operating_unit_ids": [(6, 0, [ou_b.id])],
+            }
+        )
+        form = Form(self.env["account.move"].with_context(default_move_type="entry"))
+        form.operating_unit_id = ou_b
+        self.assertEqual(form.journal_id.id, journal_b.id)
+        self.assertNotEqual(ou_a.id, ou_b.id)
+
+    # ------------------------------------------------------------------
+    # Constraints — require assertRaises(UserError), not expressible in YAML.
+    # ------------------------------------------------------------------
+
+    def test_check_company_operating_unit_mismatch_raises(self):
+        """OU belonging to a different company than the move must be rejected."""
+        other_company = self.env["res.company"].create(
+            {"name": "Test Other Company OU"}
+        )
+        partner = self.env["res.partner"].create({"name": "Other Company OU Partner"})
+        other_ou = self.env["operating.unit"].create(
+            {
+                "name": "Other Company OU",
+                "code": "OTHERCOU",
+                "partner_id": partner.id,
+                "company_id": other_company.id,
+            }
+        )
+        journal = self.env["account.journal"].create(
+            {"name": "Test Company Check Journal", "code": "TSTCCJ", "type": "general"}
+        )
+        with self.assertRaises(UserError):
+            self.env["account.move"].create(
+                {
+                    "move_type": "entry",
+                    "journal_id": journal.id,
+                    "company_id": self.company.id,
+                    "operating_unit_id": other_ou.id,
+                }
+            )
+
+    def test_check_journal_operating_unit_mismatch_raises_for_account_move_active_model(
+        self,
+    ):
+        """Mismatched OU/journal must raise when active_model is account.move
+        itself (no self-heal branch)."""
+        ou_a = self._create_operating_unit("Test Journal Check OU A", "TESTJCKA")
+        ou_b = self._create_operating_unit("Test Journal Check OU B", "TESTJCKB")
+        journal_a = self.env["account.journal"].create(
+            {
+                "name": "Test Journal Check A",
+                "code": "TSTJCKJA",
+                "type": "general",
+                "operating_unit_ids": [(6, 0, [ou_a.id])],
+            }
+        )
+        with self.assertRaises(UserError):
+            self.env["account.move"].with_context(active_model="account.move").create(
+                {
+                    "move_type": "entry",
+                    "journal_id": journal_a.id,
+                    "operating_unit_id": ou_b.id,
+                }
+            )
+
+    def test_check_journal_operating_unit_self_heals_for_other_active_model(self):
+        """When created from another model (e.g. sale.order), a mismatched
+        journal is healed by re-selecting a journal that matches the OU,
+        instead of raising."""
+        ou_a = self._create_operating_unit("Test Heal OU A", "TESTHEALA")
+        ou_b = self._create_operating_unit("Test Heal OU B", "TESTHEALB")
+        journal_a = self.env["account.journal"].create(
+            {
+                "name": "Test Heal Journal A",
+                "code": "TSTHEALJA",
+                "type": "general",
+                "operating_unit_ids": [(6, 0, [ou_a.id])],
+            }
+        )
+        journal_b = self.env["account.journal"].create(
+            {
+                "name": "Test Heal Journal B",
+                "code": "TSTHEALJB",
+                "type": "general",
+                "operating_unit_ids": [(6, 0, [ou_b.id])],
+            }
+        )
+        move = (
+            self.env["account.move"]
+            .with_context(active_model="sale.order")
+            .create(
+                {
+                    "move_type": "entry",
+                    "journal_id": journal_a.id,
+                    "operating_unit_id": ou_b.id,
+                }
+            )
+        )
+        self.assertEqual(move.journal_id, journal_b)
+
+    # ------------------------------------------------------------------
+    # BL-0041 / BL-0042 — record rule configuration + functional isolation.
+    # ------------------------------------------------------------------
+
+    def test_rule_account_move_domain_force_has_ou_empty_fallback(self):
+        rule = self.env.ref(
+            "ssi_financial_accounting_operating_unit.account_move_rule_ou"
+        )
+        domain = rule.domain_force.replace(" ", "").replace("\n", "")
+        self.assertIn("'operating_unit_id','=',False", domain)
+
+    def test_rule_account_move_line_domain_force_has_ou_empty_fallback(self):
+        rule = self.env.ref(
+            "ssi_financial_accounting_operating_unit.account_move_line_rule_ou"
+        )
+        domain = rule.domain_force.replace(" ", "").replace("\n", "")
+        self.assertIn("'operating_unit_id','=',False", domain)
+
+    def test_rule_account_bank_statement_domain_force_has_ou_empty_fallback(self):
+        rule = self.env.ref(
+            "ssi_financial_accounting_operating_unit.account_bank_statement_rule_ou"
+        )
+        domain = rule.domain_force.replace(" ", "").replace("\n", "")
+        self.assertIn("'operating_unit_id','=',False", domain)
+
+    def test_rule_account_payment_domain_force_has_ou_empty_fallback(self):
+        rule = self.env.ref(
+            "ssi_financial_accounting_operating_unit.account_payment_rule_ou"
+        )
+        domain = rule.domain_force.replace(" ", "").replace("\n", "")
+        self.assertIn("'operating_unit_id','=',False", domain)
+
+    def test_rule_account_payment_groups_include_customer_and_vendor_ou_groups(self):
+        """BL-0042: the payment rule must apply to the payment-specific OU
+        groups, not to journal_entry_ou_group."""
+        rule = self.env.ref(
+            "ssi_financial_accounting_operating_unit.account_payment_rule_ou"
+        )
+        customer_group = self.env.ref(
+            "ssi_financial_accounting_operating_unit.customer_payment_ou_group"
+        )
+        vendor_group = self.env.ref(
+            "ssi_financial_accounting_operating_unit.vendor_payment_ou_group"
+        )
+        self.assertEqual(set(rule.groups.ids), {customer_group.id, vendor_group.id})
+
+    def test_rule_account_move_visibility_fallback_and_isolation(self):
+        """BL-0041: a user scoped to OU A sees OU A moves and no-OU moves,
+        but not OU B moves."""
+        ou_a = self._create_operating_unit("Test Rule Move OU A", "TESTRULEMA")
+        ou_b = self._create_operating_unit("Test Rule Move OU B", "TESTRULEMB")
+        journal = self.env["account.journal"].create(
+            {"name": "Test Rule Move Journal", "code": "TSTRULEMJ", "type": "general"}
+        )
+        move_a = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": journal.id,
+                "operating_unit_id": ou_a.id,
+            }
+        )
+        move_none = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": journal.id,
+                "operating_unit_id": False,
+            }
+        )
+        move_b = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": journal.id,
+                "operating_unit_id": ou_b.id,
+            }
+        )
+        user = self._create_ou_scoped_user(
+            "test_rule_move_user",
+            ["ssi_financial_accounting_operating_unit.journal_entry_ou_group"],
+            ou_a,
+        )
+        visible = (
+            self.env["account.move"]
+            .with_user(user)
+            .search([("id", "in", (move_a + move_none + move_b).ids)])
+        )
+        self.assertEqual(set(visible.ids), {move_a.id, move_none.id})
+
+    def test_rule_account_bank_statement_visibility_fallback_and_isolation(self):
+        """BL-0041: same fallback+isolation guarantee for account.bank.statement."""
+        ou_a = self._create_operating_unit("Test Rule Stmt OU A", "TESTRULESA")
+        ou_b = self._create_operating_unit("Test Rule Stmt OU B", "TESTRULESB")
+        journal = self.env["account.journal"].create(
+            {"name": "Test Rule Stmt Journal", "code": "TSTRULESJ", "type": "bank"}
+        )
+        statement_a = self.env["account.bank.statement"].create(
+            {"name": "Stmt A", "journal_id": journal.id, "operating_unit_id": ou_a.id}
+        )
+        statement_none = self.env["account.bank.statement"].create(
+            {
+                "name": "Stmt None",
+                "journal_id": journal.id,
+                "operating_unit_id": False,
+            }
+        )
+        statement_b = self.env["account.bank.statement"].create(
+            {"name": "Stmt B", "journal_id": journal.id, "operating_unit_id": ou_b.id}
+        )
+        user = self._create_ou_scoped_user(
+            "test_rule_statement_user",
+            ["ssi_financial_accounting_operating_unit.bank_statement_ou_group"],
+            ou_a,
+        )
+        visible = (
+            self.env["account.bank.statement"]
+            .with_user(user)
+            .search([("id", "in", (statement_a + statement_none + statement_b).ids)])
+        )
+        self.assertEqual(set(visible.ids), {statement_a.id, statement_none.id})
+
+    # ------------------------------------------------------------------
+    # account.statement.import._complete_stmts_vals — OU assignment on import.
+    # ------------------------------------------------------------------
+
+    def test_complete_stmts_vals_single_operating_unit(self):
+        ou_a = self._create_operating_unit("Test Import OU A", "TESTIMPA")
+        journal = self.env["account.journal"].create(
+            {
+                "name": "Test Import Journal Single OU",
+                "code": "TSTIMPJ1",
+                "type": "bank",
+                "operating_unit_ids": [(6, 0, [ou_a.id])],
+            }
+        )
+        wizard = self.env["account.statement.import"].new({})
+        stmts_vals = [{"transactions": [{"payment_ref": "Test Import Line"}]}]
+        result = wizard._complete_stmts_vals(stmts_vals, journal, "1234567890")
+        self.assertEqual(result[0]["operating_unit_id"], ou_a.id)
+
+    def test_complete_stmts_vals_multiple_operating_units_default_match(self):
+        ou_a = self._create_operating_unit("Test Import Multi OU A", "TESTIMPMA")
+        ou_b = self._create_operating_unit("Test Import Multi OU B", "TESTIMPMB")
+        journal = self.env["account.journal"].create(
+            {
+                "name": "Test Import Journal Multi OU",
+                "code": "TSTIMPJ2",
+                "type": "bank",
+                "operating_unit_ids": [(6, 0, [ou_a.id, ou_b.id])],
+            }
+        )
+        user = self._create_ou_scoped_user(
+            "test_import_default_user",
+            ["ssi_financial_accounting_operating_unit.bank_statement_ou_group"],
+            ou_a + ou_b,
+        )
+        user.default_operating_unit_id = ou_b
+        wizard = self.env["account.statement.import"].with_user(user).new({})
+        stmts_vals = [{"transactions": [{"payment_ref": "Test Import Line"}]}]
+        result = wizard._complete_stmts_vals(stmts_vals, journal, "1234567890")
+        self.assertEqual(result[0]["operating_unit_id"], ou_b.id)
+
+    def test_complete_stmts_vals_multiple_operating_units_no_default_match(self):
+        ou_a = self._create_operating_unit("Test Import NoMatch OU A", "TESTIMPNA")
+        ou_b = self._create_operating_unit("Test Import NoMatch OU B", "TESTIMPNB")
+        ou_other = self._create_operating_unit(
+            "Test Import NoMatch OU Other", "TESTIMPNO"
+        )
+        journal = self.env["account.journal"].create(
+            {
+                "name": "Test Import Journal NoMatch",
+                "code": "TSTIMPJ3",
+                "type": "bank",
+                "operating_unit_ids": [(6, 0, [ou_a.id, ou_b.id])],
+            }
+        )
+        user = self._create_ou_scoped_user(
+            "test_import_nomatch_user",
+            ["ssi_financial_accounting_operating_unit.bank_statement_ou_group"],
+            ou_a + ou_b + ou_other,
+        )
+        user.default_operating_unit_id = ou_other
+        wizard = self.env["account.statement.import"].with_user(user).new({})
+        stmts_vals = [{"transactions": [{"payment_ref": "Test Import Line"}]}]
+        result = wizard._complete_stmts_vals(stmts_vals, journal, "1234567890")
+        self.assertEqual(result[0]["operating_unit_id"], ou_a.id)

--- a/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
+++ b/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
@@ -35,17 +35,38 @@ class TestSsiFinancialAccountingOperatingUnit(YamlTransactionCase):
             }
         )
 
-    def _create_ou_scoped_user(self, login, group_xmlids, operating_units):
-        # account.group_account_readonly grants the base ACL (ir.model.access)
-        # to read account.move/account.bank.statement/account.payment; without
-        # it the OU-scoped group alone only affects the ir.rule (row-level)
-        # layer and every read is rejected before the rule is even evaluated.
-        group_ids = [
-            self.env.ref("base.group_user").id,
-            self.env.ref("account.group_account_readonly").id,
-        ]
+    def _create_ou_scoped_user(
+        self, login, group_xmlids, operating_units, model_names=None
+    ):
+        group_ids = [self.env.ref("base.group_user").id]
         for xmlid in group_xmlids:
             group_ids.append(self.env.ref(xmlid).id)
+        if model_names:
+            # ir.rule is only reached after ir.model.access (ACL) passes, so
+            # the OU group alone isn't enough to read the model at all. Grant
+            # read ACL straight to the OU-scoped group(s) instead of a stock
+            # accounting group (group_account_invoice/group_account_readonly):
+            # both of those carry an unrestricted "(1,'=',1)" ir.rule for
+            # account.move/account.move.line (odoo/addons/account/security/
+            # account_security.xml), which would OR-combine with our
+            # restrictive rule and defeat the isolation being tested here —
+            # and, in production, means any user holding those stock groups
+            # bypasses OU isolation on account.move entirely regardless of
+            # this module.
+            for xmlid in group_xmlids:
+                group = self.env.ref(xmlid)
+                for model_name in model_names:
+                    self.env["ir.model.access"].create(
+                        {
+                            "name": "test_ou_read_%s_%s" % (model_name, group.id),
+                            "model_id": self.env["ir.model"]._get(model_name).id,
+                            "group_id": group.id,
+                            "perm_read": True,
+                            "perm_write": False,
+                            "perm_create": False,
+                            "perm_unlink": False,
+                        }
+                    )
         return self.env["res.users"].create(
             {
                 "name": login,
@@ -372,6 +393,7 @@ class TestSsiFinancialAccountingOperatingUnit(YamlTransactionCase):
             "test_rule_move_user",
             ["ssi_financial_accounting_operating_unit.journal_entry_ou_group"],
             ou_a,
+            model_names=["account.move"],
         )
         visible = (
             self.env["account.move"]
@@ -404,6 +426,7 @@ class TestSsiFinancialAccountingOperatingUnit(YamlTransactionCase):
             "test_rule_statement_user",
             ["ssi_financial_accounting_operating_unit.bank_statement_ou_group"],
             ou_a,
+            model_names=["account.bank.statement"],
         )
         visible = (
             self.env["account.bank.statement"]


### PR DESCRIPTION
## Summary
- Add empty-OU fallback (`operating_unit_id = False`) to the record rules for `account.move`, `account.move.line`, and `account.bank.statement` so historical/no-OU records stay visible to users scoped to an Operating Unit.
- Add dedicated Operating Unit groups for Customer Payment and Vendor Payment, and rewire the `account.payment` record rule to them (it previously used `journal_entry_ou_group`, so OU isolation on payments didn't apply to users outside that group).
- Make `operating_unit_id` on `account.move` readonly once the move leaves draft.
- Fix a potential `IndexError` in `_onchange_operating_unit` when `journal_id` is empty.
- Declare `account_statement_import` as an explicit manifest dependency (previously only pulled in transitively via `ssi_financial_accounting`).
- Rewrite the test suite using `odoo-yaml-test` (`YamlTransactionCase`) for CRUD scenarios, plus Python tests for rule/constraint/onchange behavior the YAML DSL can't express (exception assertions, dynamic-user isolation checks). Removes the old field-existence-only tests that silently skipped when fixture data was missing.

## Test plan
- [x] `odoo -u ssi_financial_accounting_operating_unit --stop-after-init` completes locally without errors.
- [x] `pre-commit run --all-files` passes (only pre-existing, non-blocking `manifest-required-author` optional-check notices repo-wide).
- [ ] CI test suite green on this PR.