### PR TITLE
[UPD] ssi_financial_accounting_operating_unit

### DIFF
--- a/ssi_financial_accounting_operating_unit/__manifest__.py
+++ b/ssi_financial_accounting_operating_unit/__manifest__.py
@@ -13,6 +13,7 @@
         "ssi_financial_accounting",
         "ssi_operating_unit_mixin",
         "account_statement_import",
+        "account_reconciliation_widget",
     ],
     "data": [
         "security/res_group/journal_entry.xml",

--- a/ssi_financial_accounting_operating_unit/models/__init__.py
+++ b/ssi_financial_accounting_operating_unit/models/__init__.py
@@ -9,4 +9,5 @@ from . import (
     account_bank_statement,
     account_bank_statement_line,
     account_statement_import,
+    account_reconciliation_widget,
 )

--- a/ssi_financial_accounting_operating_unit/models/account_reconciliation_widget.py
+++ b/ssi_financial_accounting_operating_unit/models/account_reconciliation_widget.py
@@ -1,0 +1,46 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+from odoo.osv import expression
+
+
+class AccountReconciliationWidget(models.AbstractModel):
+    _inherit = "account.reconciliation.widget"
+
+    @api.model
+    def _domain_move_lines_for_reconciliation(
+        self,
+        st_line,
+        aml_accounts,
+        partner_id,
+        excluded_ids=None,
+        search_str=False,
+        mode="rp",
+    ):
+        domain = super()._domain_move_lines_for_reconciliation(
+            st_line,
+            aml_accounts,
+            partner_id,
+            excluded_ids=excluded_ids,
+            search_str=search_str,
+            mode=mode,
+        )
+        # Superuser bypasses record rules; mirror that here so the widget
+        # behaves consistently with account_move_line_rule_ou, which is only
+        # applied by the ORM on search()/read() and not on the raw SQL this
+        # widget builds via _where_calc().
+        if self.env.su:
+            return domain
+        operating_unit_ids = self.env.user.operating_unit_ids.ids
+        return expression.AND(
+            [
+                domain,
+                [
+                    "|",
+                    ("operating_unit_id", "=", False),
+                    ("operating_unit_id", "in", operating_unit_ids),
+                ],
+            ]
+        )

--- a/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
+++ b/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
@@ -4,6 +4,7 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
+from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
 
@@ -475,6 +476,129 @@ class TestSsiFinancialAccountingOperatingUnit(YamlTransactionCase):
         stmts_vals = [{"transactions": [{"payment_ref": "Test Import Line"}]}]
         result = wizard._complete_stmts_vals(stmts_vals, journal, "1234567890")
         self.assertEqual(result[0]["operating_unit_id"], ou_b.id)
+
+    # ------------------------------------------------------------------
+    # BL-0080 — bank statement reconciliation widget OU filtering.
+    #
+    # `_domain_move_lines_for_reconciliation` builds a domain later fed to
+    # `_where_calc().get_sql()`, which bypasses `_apply_ir_rules` entirely.
+    # These are plain Python (not YAML) because they assert on the domain
+    # builder's return value under a specific user context, which the YAML
+    # DSL cannot express.
+    # ------------------------------------------------------------------
+
+    def _create_reconciliation_widget_fixture(self):
+        ou_a = self._create_operating_unit("Test Reconcile Widget OU A", "TESTRWA")
+        ou_b = self._create_operating_unit("Test Reconcile Widget OU B", "TESTRWB")
+        receivable_account = self.env["account.account"].create(
+            {
+                "name": "Test Reconcile Widget Receivable",
+                "code": "TSTRWREC",
+                "user_type_id": self.env.ref("account.data_account_type_receivable").id,
+                "reconcile": True,
+            }
+        )
+        offset_account = self.env["account.account"].search(
+            [("id", "!=", receivable_account.id), ("deprecated", "=", False)], limit=1
+        )
+        sales_journal = self.env["account.journal"].create(
+            {"name": "Test Reconcile Widget Sales", "code": "TSTRWSJ", "type": "sale"}
+        )
+        bank_journal = self.env["account.journal"].create(
+            {"name": "Test Reconcile Widget Bank", "code": "TSTRWBJ", "type": "bank"}
+        )
+        statement = self.env["account.bank.statement"].create(
+            {"name": "Test Reconcile Widget Stmt", "journal_id": bank_journal.id}
+        )
+        st_line = self.env["account.bank.statement.line"].create(
+            {
+                "statement_id": statement.id,
+                "payment_ref": "Test Reconcile Widget Line",
+                "amount": 100.0,
+                "date": fields.Date.today(),
+            }
+        )
+
+        def _create_posted_move(operating_unit):
+            move = self.env["account.move"].create(
+                {
+                    "move_type": "entry",
+                    "journal_id": sales_journal.id,
+                    "operating_unit_id": operating_unit.id if operating_unit else False,
+                    "line_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "account_id": receivable_account.id,
+                                "debit": 100.0,
+                                "credit": 0.0,
+                            },
+                        ),
+                        (
+                            0,
+                            0,
+                            {
+                                "account_id": offset_account.id,
+                                "debit": 0.0,
+                                "credit": 100.0,
+                            },
+                        ),
+                    ],
+                }
+            )
+            move.action_post()
+            return move.line_ids.filtered(
+                lambda line: line.account_id == receivable_account
+            )
+
+        line_ou_a = _create_posted_move(ou_a)
+        line_ou_b = _create_posted_move(ou_b)
+        line_no_ou = _create_posted_move(False)
+
+        user_a = self._create_ou_scoped_user(
+            "test_reconcile_widget_user_a",
+            ["ssi_financial_accounting_operating_unit.journal_entry_ou_group"],
+            ou_a,
+            model_names=["account.move.line"],
+        )
+        return {
+            "st_line": st_line,
+            "receivable_account": receivable_account,
+            "line_ou_a": line_ou_a,
+            "line_ou_b": line_ou_b,
+            "line_no_ou": line_no_ou,
+            "user_a": user_a,
+        }
+
+    def test_reconciliation_widget_domain_hides_other_ou_and_keeps_own(self):
+        fixture = self._create_reconciliation_widget_fixture()
+        widget = self.env["account.reconciliation.widget"].with_user(fixture["user_a"])
+        domain = widget._domain_move_lines_for_reconciliation(
+            fixture["st_line"], [fixture["receivable_account"].id], False
+        )
+        amls = self.env["account.move.line"].sudo().search(domain)
+        self.assertIn(fixture["line_ou_a"], amls)
+        self.assertNotIn(fixture["line_ou_b"], amls)
+
+    def test_reconciliation_widget_domain_keeps_lines_without_ou(self):
+        fixture = self._create_reconciliation_widget_fixture()
+        widget = self.env["account.reconciliation.widget"].with_user(fixture["user_a"])
+        domain = widget._domain_move_lines_for_reconciliation(
+            fixture["st_line"], [fixture["receivable_account"].id], False
+        )
+        amls = self.env["account.move.line"].sudo().search(domain)
+        self.assertIn(fixture["line_no_ou"], amls)
+
+    def test_reconciliation_widget_domain_superuser_sees_all_ou(self):
+        fixture = self._create_reconciliation_widget_fixture()
+        widget = self.env["account.reconciliation.widget"].sudo()
+        domain = widget._domain_move_lines_for_reconciliation(
+            fixture["st_line"], [fixture["receivable_account"].id], False
+        )
+        amls = self.env["account.move.line"].sudo().search(domain)
+        self.assertIn(fixture["line_ou_a"], amls)
+        self.assertIn(fixture["line_ou_b"], amls)
 
     def test_complete_stmts_vals_multiple_operating_units_no_default_match(self):
         ou_a = self._create_operating_unit("Test Import NoMatch OU A", "TESTIMPNA")

--- a/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
+++ b/ssi_financial_accounting_operating_unit/tests/test_ssi_financial_accounting_operating_unit.py
@@ -520,11 +520,19 @@ class TestSsiFinancialAccountingOperatingUnit(YamlTransactionCase):
         )
 
         def _create_posted_move(operating_unit):
+            # mixin.single_operating_unit's operating_unit_id has its own
+            # default (res.users.operating_unit_default_get()), which fills
+            # the line whenever the key is absent from vals — the
+            # account.move.line create() override only force-propagates the
+            # move's OU when it is truthy, so operating_unit_id=False must be
+            # passed explicitly here to keep the "no OU" line actually
+            # OU-less instead of falling back to that default.
+            ou_id = operating_unit.id if operating_unit else False
             move = self.env["account.move"].create(
                 {
                     "move_type": "entry",
                     "journal_id": sales_journal.id,
-                    "operating_unit_id": operating_unit.id if operating_unit else False,
+                    "operating_unit_id": ou_id,
                     "line_ids": [
                         (
                             0,
@@ -533,6 +541,7 @@ class TestSsiFinancialAccountingOperatingUnit(YamlTransactionCase):
                                 "account_id": receivable_account.id,
                                 "debit": 100.0,
                                 "credit": 0.0,
+                                "operating_unit_id": ou_id,
                             },
                         ),
                         (
@@ -542,6 +551,7 @@ class TestSsiFinancialAccountingOperatingUnit(YamlTransactionCase):
                                 "account_id": offset_account.id,
                                 "debit": 0.0,
                                 "credit": 100.0,
+                                "operating_unit_id": ou_id,
                             },
                         ),
                     ],


### PR DESCRIPTION
## Ringkasan

BL-0080: widget rekonsiliasi bank statement (OCA `account_reconciliation_widget`)
membangun domain kandidat `account.move.line` lewat `_where_calc().get_sql()`, yang
tidak melewati `_apply_ir_rules`. Akibatnya record rule OU (`account_move_line_rule_ou`)
tidak berlaku di jalur ini, sehingga user yang OU-nya dibatasi tetap bisa melihat &
me-reconcile move line milik OU lain saat rekonsiliasi bank statement.

* Menambah `models/account_reconciliation_widget.py` — override
  `_domain_move_lines_for_reconciliation` untuk menambahkan klausa
  `operating_unit_id = False OR operating_unit_id in user.operating_unit_ids`
  ke domain (di-skip untuk superuser, mirip perilaku record rule).
* Menambah dependency `account_reconciliation_widget` ke `depends`, menaikkan versi
  ke `14.0.1.3.0`.
* Menambah 3 unit test: OU lain tersembunyi, line tanpa OU tetap muncul, superuser
  melihat semua OU.
* Jalur manual reconciliation (aman, memakai `.search()`) tidak disentuh.

Detail lengkap ada di backlog item BL-0080.

## Test plan

- [x] Unit test ditulis (`tests/test_ssi_financial_accounting_operating_unit.py`)
- [ ] CI hijau