### PR TITLE
[UPD] ssi_financial_accounting_operating_unit

### DIFF
--- a/ssi_financial_accounting_operating_unit/__manifest__.py
+++ b/ssi_financial_accounting_operating_unit/__manifest__.py
@@ -19,6 +19,7 @@
         "security/res_group/journal_entry.xml",
         "security/res_group/bank_statement.xml",
         "security/res_group/account_payment.xml",
+        "security/res_group/vendor_bill.xml",
         "security/ir_rule/account_journal.xml",
         "security/ir_rule/account_move.xml",
         "security/ir_rule/account_move_line.xml",

--- a/ssi_financial_accounting_operating_unit/security/res_group/vendor_bill.xml
+++ b/ssi_financial_accounting_operating_unit/security/res_group/vendor_bill.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="bill_ou_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_financial_accounting.bill_data_ownership_module_category"
+        />
+</record>
+
+<record id="ssi_financial_accounting.bill_company_group" model="res.groups">
+    <field name="implied_ids" eval="[(4, ref('bill_ou_group'))]" />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+</record>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan grup `bill_ou_group` (kategori
`bill_data_ownership_module_category`) pada
`ssi_financial_accounting_operating_unit`, mengimplikasikannya dari
`bill_company_group` yang sudah ada di `ssi_financial_accounting` — meniru
persis pola `journal_entry_ou_group`/`vendor_payment_ou_group` yang sudah
ada di modul ini.

Dibutuhkan oleh modul glue baru `ssi_vendor_bill_operating_unit`
(repo `ssi-vendor-bill`, open-synergy/ssi-vendor-bill#4) yang menambahkan
dukungan Operating Unit ke model `vendor_bill` dan mereferensikan grup ini
pada `ir.rule`-nya.

## Test plan

- [ ] CI (pre-commit + test suite) hijau di PR ini.
- Tidak ada perubahan model/field baru, murni penambahan `res.groups` +
  wiring manifest — tidak butuh skenario `odoo-yaml-test` baru di modul ini.