### PR TITLE
[FIX] ssi_financial_accounting

### DIFF
--- a/ssi_financial_accounting/models/mass_reconcile_advanced_partner.py
+++ b/ssi_financial_accounting/models/mass_reconcile_advanced_partner.py
@@ -62,11 +62,29 @@ class MassReconcileAdvancedPartner(models.TransientModel):
         """Yield only partner_id as opposite matcher."""
         yield ("partner_id", move_line["partner_id"])
 
+    @staticmethod
+    def _group_lines_sort_key(move_line):
+        """Sort key applied to a reconcile group's lines before reconciling.
+
+        `reconcile_group_ids` is a Python `set`, so iterating it yields an
+        arbitrary order unrelated to invoice date or number. Odoo core's
+        `account.move.line.reconcile()` preserves whatever order it is
+        given (it filters the recordset into debit/credit sub-lists
+        without re-sorting), so sorting here by date (oldest first) is
+        what makes an available credit apply against the oldest open
+        invoice first (FIFO) instead of whichever invoice happened to
+        land first in the unordered set.
+        """
+        return (move_line["date"], move_line["id"])
+
     def _rec_group(self, reconcile_groups, lines_by_id):
         """Override to also track partially reconciled lines.
 
         The base implementation only tracks fully reconciled lines.
-        This version also includes partial reconciliations.
+        This version also includes partial reconciliations, and sorts
+        each group's lines oldest-first (see `_group_lines_sort_key`)
+        before reconciling so partial payments settle the oldest open
+        invoice of the partner first.
         """
         reconciled_ids = []
         for group_count, reconcile_group_ids in enumerate(reconcile_groups, start=1):
@@ -76,7 +94,10 @@ class MassReconcileAdvancedPartner(models.TransientModel):
                 len(reconcile_groups),
                 reconcile_group_ids,
             )
-            group_lines = [lines_by_id[lid] for lid in reconcile_group_ids]
+            group_lines = sorted(
+                (lines_by_id[lid] for lid in reconcile_group_ids),
+                key=self._group_lines_sort_key,
+            )
             reconciled, full = self._reconcile_lines(group_lines, allow_partial=True)
             if reconciled:
                 reconciled_ids += reconcile_group_ids

--- a/ssi_financial_accounting/tests/__init__.py
+++ b/ssi_financial_accounting/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_ssi_financial_accounting  # noqa: F401
+from . import test_mass_reconcile_advanced_partner  # noqa: F401

--- a/ssi_financial_accounting/tests/test_data_mass_reconcile_advanced_partner.yaml
+++ b/ssi_financial_accounting/tests/test_data_mass_reconcile_advanced_partner.yaml
@@ -1,0 +1,190 @@
+scenarios:
+  - name: "Mass Reconcile Advanced Partner - FIFO ordering"
+    steps:
+      - step: "Create test partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Test FIFO Reconcile Partner"
+
+      - step: "Create dedicated test receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "Test FIFO Receivable"
+          code: "TESTFIFOAR"
+          user_type_id: "REF: account.data_account_type_receivable"
+          reconcile: true
+
+      - step: "Find an existing non-receivable account to balance entries against"
+        action: "search"
+        model: "account.account"
+        save_as: "offset_account"
+        domain:
+          - ["id", "!=", "EVAL: registry['receivable_account'].id"]
+          - ["deprecated", "=", false]
+        limit: 1
+
+      - step: "Create test journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "journal"
+        values:
+          name: "Test FIFO Journal"
+          code: "TSTFIFOJ"
+          type: "general"
+
+      # Newer invoice-like line, deliberately created BEFORE the older one:
+      # any code relying on creation/insertion order (e.g. the unordered
+      # Python `set` used to build a reconcile group) instead of date would
+      # still pick this line, making the final asserts fail without the fix.
+      #
+      # Both lines are created together via inline `line_ids` commands (not
+      # as two separate account.move.line creates) because Odoo rejects an
+      # unbalanced journal entry the moment a line is created standalone.
+      - step: "Create journal entry (with lines) for the newer invoice-like line"
+        action: "create"
+        model: "account.move"
+        save_as: "move_new"
+        values:
+          move_type: "entry"
+          journal_id: "EVAL: registry['journal'].id"
+          date: "EVAL: date.today()"
+          line_ids:
+            - - 0
+              - 0
+              - account_id: "EVAL: registry['receivable_account'].id"
+                partner_id: "EVAL: registry['partner'].id"
+                debit: 50.0
+                credit: 0.0
+            - - 0
+              - 0
+              - account_id: "EVAL: registry['offset_account'].id"
+                debit: 0.0
+                credit: 50.0
+
+      - step: "Post the newer move"
+        action: "call"
+        target: "move_new"
+        method: "action_post"
+        asserts:
+          state:
+            type: "value"
+            expected: "posted"
+
+      - step: "Find the newer move's receivable line"
+        action: "search"
+        model: "account.move.line"
+        save_as: "line_new"
+        domain:
+          - ["move_id", "=", "EVAL: registry['move_new'].id"]
+          - ["account_id", "=", "EVAL: registry['receivable_account'].id"]
+        limit: 1
+
+      - step: "Create journal entry (with lines) for the older invoice-like line"
+        action: "create"
+        model: "account.move"
+        save_as: "move_old"
+        values:
+          move_type: "entry"
+          journal_id: "EVAL: registry['journal'].id"
+          date: "EVAL: date.today() - timedelta(days=10)"
+          line_ids:
+            - - 0
+              - 0
+              - account_id: "EVAL: registry['receivable_account'].id"
+                partner_id: "EVAL: registry['partner'].id"
+                debit: 50.0
+                credit: 0.0
+            - - 0
+              - 0
+              - account_id: "EVAL: registry['offset_account'].id"
+                debit: 0.0
+                credit: 50.0
+
+      - step: "Post the older move"
+        action: "call"
+        target: "move_old"
+        method: "action_post"
+        asserts:
+          state:
+            type: "value"
+            expected: "posted"
+
+      - step: "Find the older move's receivable line"
+        action: "search"
+        model: "account.move.line"
+        save_as: "line_old"
+        domain:
+          - ["move_id", "=", "EVAL: registry['move_old'].id"]
+          - ["account_id", "=", "EVAL: registry['receivable_account'].id"]
+        limit: 1
+
+      - step:
+          "Create journal entry (with lines) for the partial credit (payment-like line)"
+        action: "create"
+        model: "account.move"
+        save_as: "move_payment"
+        values:
+          move_type: "entry"
+          journal_id: "EVAL: registry['journal'].id"
+          date: "EVAL: date.today()"
+          line_ids:
+            - - 0
+              - 0
+              - account_id: "EVAL: registry['receivable_account'].id"
+                partner_id: "EVAL: registry['partner'].id"
+                debit: 0.0
+                credit: 30.0
+            - - 0
+              - 0
+              - account_id: "EVAL: registry['offset_account'].id"
+                debit: 30.0
+                credit: 0.0
+
+      - step: "Post the payment move"
+        action: "call"
+        target: "move_payment"
+        method: "action_post"
+        asserts:
+          state:
+            type: "value"
+            expected: "posted"
+
+      - step: "Create mass reconcile task on the test receivable account"
+        action: "create"
+        model: "account.mass.reconcile"
+        save_as: "mass_rec"
+        values:
+          name: "test_advanced_partner_fifo"
+          account: "EVAL: registry['receivable_account'].id"
+
+      - step: "Attach the Advanced Partner Only (Partial) reconcile method"
+        action: "create"
+        model: "account.mass.reconcile.method"
+        values:
+          name: "mass.reconcile.advanced.partner"
+          task_id: "EVAL: registry['mass_rec'].id"
+
+      - step: "Run the mass reconcile"
+        action: "call"
+        target: "mass_rec"
+        method: "run_reconcile"
+
+      - step: "Assert the oldest invoice-like line was settled first (FIFO)"
+        action: "assert"
+        target: "line_old"
+        asserts:
+          amount_residual:
+            type: "value"
+            expected: 20.0
+
+      - step: "Assert the newer invoice-like line was left untouched"
+        action: "assert"
+        target: "line_new"
+        asserts:
+          amount_residual:
+            type: "value"
+            expected: 50.0

--- a/ssi_financial_accounting/tests/test_mass_reconcile_advanced_partner.py
+++ b/ssi_financial_accounting/tests/test_mass_reconcile_advanced_partner.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestMassReconcileAdvancedPartner(YamlTransactionCase):
+    def test_mass_reconcile_advanced_partner_fifo(self):
+        self.run_yaml_scenario("test_data_mass_reconcile_advanced_partner.yaml")


### PR DESCRIPTION
## Ringkasan

Metode reconcile "Advanced. Partner Only (Partial)" (`mass.reconcile.advanced.partner`)
memproses baris dalam satu grup reconcile memakai urutan Python `set` yang tidak
deterministik, sehingga pembayaran/kredit partner bisa melunasi invoice yang lebih
baru sambil melewati invoice yang lebih lama.

- Tambah `_group_lines_sort_key()` dan urutkan baris tiap grup reconcile berdasarkan
  `(date, id)` sebelum dipanggil ke `_reconcile_lines()`, supaya kredit yang tersedia
  melunasi invoice tertua partner lebih dulu (FIFO).
- Tambah unit test skenario YAML yang memverifikasi kredit parsial melunasi invoice
  lama dulu, bukan invoice baru, meski invoice baru dibuat lebih dulu.

## Test plan

- [x] Unit test baru (`test_data_mass_reconcile_advanced_partner.yaml`) — lolos di lokal.
- [x] `pre-commit run --all-files` lolos.
- [x] Modul ter-update & seluruh test suite (`ssi_financial_accounting`) lolos di server dev lokal (0 failed, 0 error dari 64 test).