### PR TITLE
[UPD] ssi_account_statement_import_mutasi_ai

### DIFF
--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -137,6 +137,15 @@ class AccountStatementImportMutasiAiJob(models.Model):
         copy=False,
         help="Bank statement(s) created from this job's extracted " "transactions.",
     )
+    notification_message = fields.Text(
+        string="Import Notification",
+        readonly=True,
+        copy=False,
+        help="Feedback returned by the import wizard about the outcome "
+        "of this job, e.g. how many transactions were ignored because "
+        "they had already been imported. Empty when the wizard reported "
+        "nothing noteworthy.",
+    )
 
     @api.model
     def create(self, vals):
@@ -195,6 +204,51 @@ Solution: Wait for the current job to finish, or check its result
         action["domain"] = [("id", "in", self.statement_ids.ids)]
         return action
 
+    def _prepare_notification_message(self, result):
+        """Build the user-facing summary of an ``import_single_statement``
+        call.
+
+        Extension point: override in a glue module to change how the
+        wizard's ``result`` dict is rendered on the job.
+
+        Normally joins the ``message`` of every dict in
+        ``result["notifications"]`` (one per line), e.g. how many
+        transactions were ignored as duplicates. ``result["details"]``
+        (the ignored line ids) is intentionally not stored.
+
+        ``_create_bank_statements``/``_update_bank_statements`` (in
+        ``ssi_account_statement_import``/upstream OCA
+        ``account_statement_import``) return early, before building
+        ``notifications``, whenever *every* transaction in the file was
+        already imported (``result["statement_ids"]`` stays empty).
+        Without a fallback that specific case would leave this field
+        empty even though it is the one situation users most need an
+        explanation for, so a generic duplicate-file message is
+        synthesized when both ``notifications`` and ``statement_ids``
+        are empty.
+
+        :param result: the ``result`` dict built by
+            ``account.statement.import.import_single_statement``
+            (keys ``statement_ids`` and ``notifications``)
+        :return: the notification text, or ``False`` when there is
+            nothing to report
+        """
+        notifications = result.get("notifications") or []
+        if notifications:
+            messages = [
+                notification["message"]
+                for notification in notifications
+                if notification.get("message")
+            ]
+            return "\n".join(messages) if messages else False
+        if not result.get("statement_ids"):
+            return _(
+                "All transactions in this file had already been "
+                "imported previously (duplicates), so no new bank "
+                "statement was created."
+            )
+        return False
+
     def _run(self):
         """Call the mutasi-ai service and import the resulting transactions.
 
@@ -249,6 +303,7 @@ Solution: Wait for the current job to finish, or check its result
                     "response_json": json.dumps(response_json),
                     "statement_ids": [(6, 0, result["statement_ids"])],
                     "error_message": False,
+                    "notification_message": self._prepare_notification_message(result),
                 }
             )
         except Exception as exc:  # noqa: BLE001 - job must never propagate

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -440,6 +440,116 @@ class TestImportMutasiAi(TransactionCase):
         self.assertIn("boom", job.error_message)
         self.assertFalse(job.statement_ids)
 
+    # ------------------------------------------------------------------
+    # notification_message — mocked HTTP call
+    # ------------------------------------------------------------------
+
+    def test_notification_message_false_when_all_new(self):
+        """No notification when the whole file is newly imported.
+
+        Positive scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; ``odoo-yaml-test`` has no
+        mock/patch support).
+        """
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        job = self._make_job(unique_suffix="notif-new")
+        with patch(
+            _CALL_SERVICE_PATH,
+            return_value=_sample_response(
+                unique_suffix="notif-new", currency_code=self.company_currency
+            ),
+        ):
+            job._run()
+        self.assertEqual(job.state, "done")
+        self.assertFalse(job.notification_message)
+
+    def test_notification_message_all_duplicate_second_run(self):
+        """Re-importing an all-duplicate file reports it on the job.
+
+        Positive scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; ``odoo-yaml-test`` has no
+        mock/patch support). Mirrors
+        ``test_run_dedup_second_run_need_review`` but also asserts the
+        new ``notification_message`` field, populated here by the
+        fallback message ``_prepare_notification_message`` synthesizes
+        when the wizard's own ``result["notifications"]`` stays empty
+        (``_create_bank_statements``/``_update_bank_statements`` return
+        before building it when every transaction was a duplicate).
+        """
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        response = _sample_response(
+            unique_suffix="notif-dup", currency_code=self.company_currency
+        )
+        job1 = self._make_job(unique_suffix="notif-dup")
+        with patch(_CALL_SERVICE_PATH, return_value=response):
+            job1._run()
+        self.assertEqual(job1.state, "done")
+
+        job2 = self._make_job(unique_suffix="notif-dup")
+        with patch(_CALL_SERVICE_PATH, return_value=response):
+            job2._run()
+        self.assertEqual(job2.state, "need_review")
+        self.assertTrue(job2.notification_message)
+        self.assertIn("already been imported", job2.notification_message)
+
+    def test_notification_message_partial_duplicate_second_run(self):
+        """A partially-duplicate re-import reports the ignored lines.
+
+        Positive scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; ``odoo-yaml-test`` has no
+        mock/patch support). With one new transaction added on top of
+        an already-imported file, the job finishes ``done`` and
+        ``notification_message`` carries the wizard's own "already
+        been imported" message instead of the all-duplicate fallback.
+        """
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        response = _sample_response(
+            unique_suffix="notif-partial", currency_code=self.company_currency
+        )
+        job1 = self._make_job(unique_suffix="notif-partial")
+        with patch(_CALL_SERVICE_PATH, return_value=response):
+            job1._run()
+        self.assertEqual(job1.state, "done")
+
+        response2 = _sample_response(
+            unique_suffix="notif-partial", currency_code=self.company_currency
+        )
+        response2["result"]["statements"][0]["transactions"].append(
+            {
+                "date": "2026-01-15",
+                "amount": 750000.0,
+                "payment_ref": "TRANSFER BARU",
+                "unique_import_id": "mutasi-ai-tx-notif-partial-new",
+                "account_number": None,
+                "partner_name": "Citra",
+                "ref": None,
+            }
+        )
+        job2 = self._make_job(unique_suffix="notif-partial")
+        with patch(_CALL_SERVICE_PATH, return_value=response2):
+            job2._run()
+        self.assertEqual(job2.state, "done")
+        self.assertTrue(job2.notification_message)
+        self.assertIn("already been imported", job2.notification_message)
+
+    def test_notification_message_false_on_failure(self):
+        """A failed job leaves ``notification_message`` untouched.
+
+        Negative scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; ``odoo-yaml-test`` has no
+        mock/patch support). ``_run``'s ``except`` branch must not set
+        ``notification_message``, so it stays at its default (empty)
+        value.
+        """
+        job = self._make_job(unique_suffix="notif-error")
+        with patch(_CALL_SERVICE_PATH, side_effect=UserError("boom")):
+            job._run()
+        self.assertEqual(job.state, "failed")
+        self.assertFalse(job.notification_message)
+
     def test_retry_only_allowed_from_failed_or_need_review(self):
         job = self._make_job(unique_suffix="retryguard")
         with self.assertRaises(UserError):

--- a/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
+++ b/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
@@ -62,6 +62,9 @@
                     </group>
                 </group>
                 <notebook>
+                    <page name="notification" string="Import Notification">
+                        <field name="notification_message" nolabel="1" />
+                    </page>
                     <page name="error" string="Error">
                         <field name="error_message" nolabel="1" />
                     </page>


### PR DESCRIPTION
## Ringkasan

Simpan hasil `result["notifications"]` dari wizard import ke record job
mutasi-ai (`account.statement.import.mutasi.ai.job`), sebelumnya dibuang
total sehingga pengguna melihat badge kuning `Need Review` tanpa keterangan
apa pun.

- Field baru `notification_message` (`Text`, `readonly=True`, `copy=False`,
  `help` bahasa Inggris), diisi lewat method privat baru
  `_prepare_notification_message(result)` di `_run()`, sejajar dengan
  `error_message` yang sudah ada.
- Isi normal = gabungan `message` dari tiap dict `result["notifications"]`,
  satu pesan per baris (`details` tidak disimpan).
- Fallback: saat file yang diimpor 100% berisi transaksi duplikat,
  `_create_bank_statements`/`_update_bank_statements` (OCA/SSI) early-return
  sebelum sempat membangun `notifications`, sehingga tanpa fallback field ini
  akan tetap kosong tepat di skenario yang memotivasi issue ini. Keputusan
  ini didiskusikan & disetujui di komentar issue sebelum diimplementasikan.
- Jalur `except` di `_run()` tidak menyentuh field ini — nilai sebelumnya
  dibiarkan apa adanya.
- Field ditampilkan di form view job pada halaman notebook baru "Import
  Notification", mengikuti pola halaman `error`/`response` yang sudah ada.
- Tidak ada `action_*` baru/berubah, tidak ada ACL/record rule baru, tidak
  ada dependensi manifest baru.

## Unit test

Empat skenario Python murni (trigger P6, keterbatasan L-15 — `_run()` wajib
memalsukan `_call_service`, `odoo-yaml-test` tidak punya mock/patch):

- Impor pertama (dua transaksi baru) → `notification_message` = `False`.
- Impor kedua, respons sama persis (semua duplikat) → `state` tetap
  `need_review`, `notification_message` memuat substring
  `already been imported` (lewat fallback).
- Impor kedua dengan satu transaksi tambahan (sebagian duplikat) →
  `state` = `done`, `notification_message` memuat pesan transaksi
  terabaikan.
- `_call_service` melempar `UserError` → `state` = `failed`,
  `notification_message` tetap `False`.

Closes #108