### PR TITLE
[UPD] ssi_account_statement_import_mutasi_ai

### DIFF
--- a/.github/workflows/notify-telegram.yml
+++ b/.github/workflows/notify-telegram.yml
@@ -1,3 +1,30 @@
+# Caller tipis untuk reusable workflow `andhit-r/notify-telegram`.
+#
+# Seluruh logika notifikasi ada di hulu; berkas ini sengaja tidak memuat apa pun selain
+# trigger + pemanggilan, supaya perbaikan di hulu menyebar tanpa menyentuh repo modul.
+# JANGAN menyalin kembali logika inline ke sini — itu persis kebiasaan yang membuat satu
+# bug ikut tersalin ke 130 repo: Telegram menolak pesan lebih dari 4096 karakter dengan
+# `400 message is too long`, sehingga seluruh run CI jadi merah.
+#
+# Nilai branch di bawah diisi apply-ssi-overrides.sh sesuai versi repo (14.0, 19.0, …).
+# Placeholder-nya sengaja TIDAK disebut di komentar mana pun: substitusinya `sed` polos,
+# jadi penyebutan di komentar ikut tertimpa dan kalimatnya berubah jadi tak bermakna.
+#
+# Repo hulu bersifat PUBLIK, jadi repo di org mana pun — termasuk `open-synergy` — boleh
+# MEMANGGIL-nya; reusable workflow privat hanya bisa dipanggil repo milik owner yang sama.
+#
+# TAPI IZIN MEMANGGIL DAN PEWARISAN SECRET ADALAH DUA ATURAN BERBEDA. `secrets: inherit`
+# hanya bekerja bila pemanggil dan reusable workflow berada di organisasi/enterprise yang
+# SAMA. Repo `open-synergy/*` memanggil workflow milik user `andhit-r` — beda owner —
+# sehingga `inherit` TIDAK meneruskan secret org dan seluruh run gagal SEBELUM job jalan:
+#   Error when evaluating 'secrets'. ...
+#   Secret TELEGRAM_CODE_BOT_TOKEN is required, but not provided while calling.
+# Karena itu kedua secret DITERUSKAN EKSPLISIT di bawah: ekspresi `${{ secrets.* }}`
+# dievaluasi di konteks pemanggil, jadi secret level repo MAUPUN level org sama-sama
+# terbaca, lintas owner sekalipun. JANGAN kembalikan ke `secrets: inherit`.
+#
+# Secret yang wajib tersedia bagi repo modul (level repo ATAU level org):
+# TELEGRAM_CODE_BOT_TOKEN, TELEGRAM_CHAT_ID.
 name: Notify Telegram on Push
 
 on:
@@ -7,89 +34,7 @@ on:
 
 jobs:
   notify:
-    name: Send Telegram Notification
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Build and send Telegram message
-        # Semua data dinamis dilewatkan lewat env (di-set GitHub dengan aman),
-        # BUKAN ditanam ke skrip shell. Mencegah error sintaks & script injection
-        # bila pesan commit mengandung ' ` $() < > & atau karakter khusus lain.
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_CODE_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          REPO: ${{ github.repository }}
-          BRANCH: ${{ github.ref_name }}
-          PUSHER: ${{ github.actor }}
-          COMPARE_URL: ${{ github.event.compare }}
-          COMMITS_JSON: ${{ toJson(github.event.commits) }}
-        # Heredoc ber-quote <<'PYEOF': bash TIDAK menginterpolasi isi Python.
-        run: |
-          python3 <<'PYEOF'
-          import os, json, html, urllib.request, urllib.parse, urllib.error
-
-          repo    = os.environ["REPO"]
-          branch  = os.environ["BRANCH"]
-          pusher  = os.environ["PUSHER"]
-          compare = os.environ["COMPARE_URL"]
-          commits = json.loads(os.environ.get("COMMITS_JSON") or "[]")
-
-          # Telegram HTML hanya kenal &lt; &gt; &amp;; jangan escape kutip
-          # (entity numerik apostrof ditolak parser).
-          def esc(s):
-              return html.escape(s, quote=False)
-
-          lines = []
-          for c in commits:
-              sha    = c["id"][:7]
-              msg    = c["message"].strip()
-              author = esc(c["author"]["name"])
-              ts     = c["timestamp"][:16].replace("T", " ")  # YYYY-MM-DD HH:MM
-
-              msg_lines = msg.split("\n")
-              title = esc(msg_lines[0][:80])  # baris pertama, maks 80 karakter
-              body  = [esc(l) for l in msg_lines[1:] if l.strip()]
-
-              entry = f"  <code>{sha}</code> {title}\n    👤 {author}  🕐 {ts}"
-              if body:
-                  entry += "\n" + "\n".join(f"    {l}" for l in body)
-              lines.append(entry)
-
-          count = len(commits)
-          if count == 1:
-              header = f"📝 <b>1 commit baru</b> di <code>{esc(repo)}</code>"
-          else:
-              header = f"📦 <b>{count} commit baru</b> di <code>{esc(repo)}</code>"
-
-          message = (
-              f"{header}\n"
-              f"Branch: <code>{esc(branch)}</code>\n"
-              f"Pusher: @{esc(pusher)}\n\n"
-              + "\n\n".join(lines)
-              + f'\n\n🔗 <a href="{esc(compare)}">Lihat perubahan</a>'
-          )
-
-          data = urllib.parse.urlencode({
-              "chat_id": os.environ["TELEGRAM_CHAT_ID"],
-              "text": message,
-              "parse_mode": "HTML",
-              "disable_web_page_preview": "true",
-          }).encode()
-
-          url = f'https://api.telegram.org/bot{os.environ["TELEGRAM_BOT_TOKEN"]}/sendMessage'
-          try:
-              with urllib.request.urlopen(urllib.request.Request(url, data=data)) as resp:
-                  result = json.load(resp)
-          except urllib.error.HTTPError as e:
-              result = json.load(e)
-
-          print("Telegram response:", json.dumps(result, ensure_ascii=False))
-          if not result.get("ok"):
-              print("::error::Gagal kirim pesan Telegram")
-              raise SystemExit(1)
-          PYEOF
+    uses: andhit-r/notify-telegram/.github/workflows/notify.yml@v1
+    secrets:
+      TELEGRAM_CODE_BOT_TOKEN: ${{ secrets.TELEGRAM_CODE_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -80,9 +80,9 @@ class AccountStatementImportMutasiAiJob(models.Model):
         selection=[
             ("draft", "Draft"),
             ("queued", "Queued"),
-            ("processing", "Processing"),
             ("done", "Done"),
             ("need_review", "Need Review"),
+            ("already_imported", "Already Imported"),
             ("failed", "Failed"),
         ],
         default="draft",
@@ -93,9 +93,11 @@ class AccountStatementImportMutasiAiJob(models.Model):
             "Job status: "
             "Draft = not yet queued, "
             "Queued = waiting for a queue_job worker, "
-            "Processing = currently calling the mutasi-ai service, "
             "Done = statement imported successfully, "
             "Need Review = imported but mutasi-ai flagged low confidence, "
+            "Already Imported = every transaction in the file had "
+            "already been imported previously, so no new statement was "
+            "created, "
             "Failed = the service call or import raised an error."
         ),
     )
@@ -258,7 +260,6 @@ Solution: Wait for the current job to finish, or check its result
         relying on queue_job's own retry/failure handling.
         """
         self.ensure_one()
-        self.write({"state": "processing"})
         try:
             data_file = base64.b64decode(self.attachment_id.datas or b"")
             filename = self.statement_filename or self.attachment_id.name or "statement"
@@ -291,9 +292,14 @@ Solution: Wait for the current job to finish, or check its result
             result = {"statement_ids": [], "notifications": []}
             wizard.import_single_statement(triplet, result)
 
-            state = "need_review" if external_status == "need_review" else "done"
             if not result["statement_ids"]:
-                state = "need_review"
+                # Every transaction in the file was already imported, so
+                # there is nothing left to review; this overrides
+                # ``external_status`` even when the service itself
+                # flagged the file as "need_review".
+                state = "already_imported"
+            else:
+                state = "need_review" if external_status == "need_review" else "done"
 
             self.write(
                 {

--- a/ssi_account_statement_import_mutasi_ai/tests/__init__.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import test_mutasi_ai_backend
 from . import test_import_mutasi_ai
+from . import test_account_statement_import_mutasi_ai_job_state

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_state.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_state.py
@@ -1,0 +1,15 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountStatementImportMutasiAiJobState(YamlTransactionCase):
+    """Field-only scenario tests for the job ``state`` selection."""
+
+    def test_account_statement_import_mutasi_ai_job_state(self):
+        """Run the ``state`` selection negative-path scenarios."""
+        self.run_yaml_scenario("test_account_statement_import_mutasi_ai_job_state.yaml")

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_state.yaml
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_state.yaml
@@ -1,0 +1,68 @@
+scenarios:
+  - name: "Reject obsolete processing state"
+    steps:
+      - step: "Create statement attachment"
+        action: "create"
+        model: "ir.attachment"
+        save_as: "attachment"
+        values:
+          name: "statement.pdf"
+          datas: "ZHVtbXkgcGRmIGNvbnRlbnQ="
+          type: "binary"
+      - step: "Create mutasi-ai backend"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.backend"
+        save_as: "backend"
+        values:
+          name: "State Test Backend"
+          code: "STATE-TEST-BACKEND-1"
+          base_url: "https://carik.example.com"
+          bearer_token: "test-token"
+      - step: "Create job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+      - step: "Writing obsolete processing state must be rejected"
+        action: "write"
+        target: "job"
+        expect_error:
+          type: "ValueError"
+        values:
+          state: "processing"
+
+  - name: "Retry blocked once a job is already_imported"
+    steps:
+      - step: "Create statement attachment"
+        action: "create"
+        model: "ir.attachment"
+        save_as: "attachment"
+        values:
+          name: "statement.pdf"
+          datas: "ZHVtbXkgcGRmIGNvbnRlbnQ="
+          type: "binary"
+      - step: "Create mutasi-ai backend"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.backend"
+        save_as: "backend"
+        values:
+          name: "State Test Backend"
+          code: "STATE-TEST-BACKEND-2"
+          base_url: "https://carik.example.com"
+          bearer_token: "test-token"
+      - step: "Create job already flagged already_imported"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+          state: "already_imported"
+      - step: "Retry on an already_imported job must be rejected"
+        action: "call"
+        target: "job"
+        method: "action_retry"
+        expect_error:
+          type: "UserError"

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -298,7 +298,18 @@ class TestImportMutasiAi(TransactionCase):
             "via mutasi_ai_job_ids",
         )
 
-    def test_run_dedup_second_run_need_review(self):
+    def test_run_dedup_second_run_already_imported(self):
+        """Re-importing an all-duplicate file is ``already_imported``.
+
+        Positive scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; ``odoo-yaml-test`` has no
+        mock/patch support). Feeding the exact same response twice
+        means every transaction on the second run is a duplicate, so
+        ``statement_ids`` stays empty and the job must land on
+        ``already_imported`` (not ``need_review``, which is reserved
+        for a low-confidence extraction that still produced new
+        transactions), with ``notification_message`` explaining why.
+        """
         if not self.bank_journal:
             self.skipTest("No bank journal found in test environment")
         response = _sample_response(
@@ -312,23 +323,26 @@ class TestImportMutasiAi(TransactionCase):
         job2 = self._make_job(unique_suffix="dedup")
         with patch(_CALL_SERVICE_PATH, return_value=response):
             job2._run()
-        # All transactions already imported -> no new statement, need_review.
-        self.assertEqual(job2.state, "need_review")
+        # All transactions already imported -> no new statement,
+        # already_imported.
+        self.assertEqual(job2.state, "already_imported")
         self.assertFalse(job2.statement_ids)
+        self.assertTrue(job2.notification_message)
         lines = self.env["account.bank.statement.line"].search(
             [("payment_ref", "=", "TRANSFER MASUK"), ("amount", "=", 500000.0)]
         )
         self.assertEqual(len(lines), 1, "deduplication failed: expected exactly 1 line")
 
-    def test_run_dedup_second_run_need_review_null_balance(self):
-        """Re-importing an all-duplicate null-balance file is need_review.
+    def test_run_dedup_second_run_already_imported_null_balance(self):
+        """Re-importing an all-duplicate null-balance file is already_imported.
 
         Positive scenario — trigger P6 (L-15: an end-to-end job run
         requires patching ``_call_service``; no mock support in YAML).
-        Null-balance variant of ``test_run_dedup_second_run_need_review``
-        reproducing the reported bug: before the fix, the second run
-        raised ``TypeError`` (``NoneType`` ``+=`` ``float``) instead of
-        finishing as ``need_review``.
+        Null-balance variant of
+        ``test_run_dedup_second_run_already_imported`` reproducing the
+        reported bug: before the fix, the second run raised
+        ``TypeError`` (``NoneType`` ``+=`` ``float``) instead of
+        finishing as ``already_imported``.
         """
         if not self.bank_journal:
             self.skipTest("No bank journal found in test environment")
@@ -347,13 +361,46 @@ class TestImportMutasiAi(TransactionCase):
         with patch(_CALL_SERVICE_PATH, return_value=response):
             job2._run()
         # All transactions already imported -> no new statement,
-        # need_review, and no TypeError even though balances are null.
-        self.assertEqual(job2.state, "need_review")
+        # already_imported, and no TypeError even though balances are
+        # null.
+        self.assertEqual(job2.state, "already_imported")
         self.assertFalse(job2.statement_ids)
         lines = self.env["account.bank.statement.line"].search(
             [("payment_ref", "=", "TRANSFER MASUK"), ("amount", "=", 500000.0)]
         )
         self.assertEqual(len(lines), 1, "deduplication failed: expected exactly 1 line")
+
+    def test_run_dedup_full_duplicate_need_review_status_wins(self):
+        """A fully-duplicate need_review response is still already_imported.
+
+        Positive scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; no mock support in YAML).
+        The duplicate-file rule (``statement_ids`` empty ->
+        ``already_imported``) must win over ``external_status`` even
+        when the mutasi-ai service itself flags the (fully duplicate)
+        file as ``need_review``.
+        """
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        response = _sample_response(
+            unique_suffix="dedup-needreview", currency_code=self.company_currency
+        )
+        job1 = self._make_job(unique_suffix="dedup-needreview")
+        with patch(_CALL_SERVICE_PATH, return_value=response):
+            job1._run()
+        self.assertEqual(job1.state, "done")
+
+        response2 = _sample_response(
+            status="need_review",
+            unique_suffix="dedup-needreview",
+            currency_code=self.company_currency,
+        )
+        job2 = self._make_job(unique_suffix="dedup-needreview")
+        with patch(_CALL_SERVICE_PATH, return_value=response2):
+            job2._run()
+        self.assertEqual(job2.state, "already_imported")
+        self.assertEqual(job2.external_status, "need_review")
+        self.assertFalse(job2.statement_ids)
 
     def test_run_second_run_null_balance_adds_new_transaction(self):
         """A second null-balance run with one new line still succeeds.
@@ -470,8 +517,8 @@ class TestImportMutasiAi(TransactionCase):
         Positive scenario — trigger P6 (L-15: an end-to-end job run
         requires patching ``_call_service``; ``odoo-yaml-test`` has no
         mock/patch support). Mirrors
-        ``test_run_dedup_second_run_need_review`` but also asserts the
-        new ``notification_message`` field, populated here by the
+        ``test_run_dedup_second_run_already_imported`` but also asserts
+        the new ``notification_message`` field, populated here by the
         fallback message ``_prepare_notification_message`` synthesizes
         when the wizard's own ``result["notifications"]`` stays empty
         (``_create_bank_statements``/``_update_bank_statements`` return
@@ -490,7 +537,7 @@ class TestImportMutasiAi(TransactionCase):
         job2 = self._make_job(unique_suffix="notif-dup")
         with patch(_CALL_SERVICE_PATH, return_value=response):
             job2._run()
-        self.assertEqual(job2.state, "need_review")
+        self.assertEqual(job2.state, "already_imported")
         self.assertTrue(job2.notification_message)
         self.assertIn("already been imported", job2.notification_message)
 

--- a/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
+++ b/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
@@ -10,6 +10,7 @@
         <tree
                 decoration-danger="state == 'failed'"
                 decoration-warning="state == 'need_review'"
+                decoration-info="state == 'already_imported'"
                 decoration-success="state == 'done'"
                 decoration-muted="state in ('draft', 'queued')"
             >


### PR DESCRIPTION
## Ringkasan

* Tambah nilai state `already_imported` (label "Already Imported") pada
  `account.statement.import.mutasi.ai.job`, disisipkan antara `need_review` dan `failed`.
* Buang nilai state `processing` beserta penulisannya di `_run()` — tidak pernah ter-commit
  terpisah sehingga tidak pernah teramati pengguna.
* Sederhanakan aturan pemilihan state di `_run()`: `statement_ids` kosong -> `already_imported`
  (menang atas `external_status` bernilai `need_review`); selain itu perilaku lama
  dipertahankan. Revisi Keputusan Desain (dead code pada syarat `notifications`) dicatat di
  komentar issue.
* Perbarui help text field `state` dan decoration tree view.
* Perbarui/tambah unit test sesuai Skenario Uji issue.

Closes #109