### PR TITLE
[UPD] ssi_account_statement_import_mutasi_ai - Cegah unggah ulang berkas identik lewat checksum SHA-256

### DIFF
--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import.py
@@ -1,10 +1,24 @@
 # Copyright 2026 OpenSynergy Indonesia
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import base64
+import hashlib
+
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class AccountStatementImport(models.TransientModel):
+    """
+    Adds the mutasi-ai async import path to the OCA import wizard.
+
+    When a Mutasi AI Backend is selected, ``import_file_button`` queues
+    an ``account.statement.import.mutasi.ai.job`` instead of parsing
+    the file synchronously, after rejecting the upload when a file
+    with the same SHA-256 checksum was already handled by another job
+    (see ``_check_mutasi_ai_duplicate``).
+    """
+
     _inherit = "account.statement.import"
 
     mutasi_ai_backend_id = fields.Many2one(
@@ -42,7 +56,20 @@ class AccountStatementImport(models.TransientModel):
         return super().import_file_button()
 
     def _enqueue_mutasi_ai_import(self):
+        """Queue an asynchronous mutasi-ai import job for this wizard.
+
+        Rejects the upload via ``_check_mutasi_ai_duplicate`` before
+        any ``ir.attachment`` or job record is created, so a file that
+        was already queued, processed, or imported is never sent to
+        the (billed) mutasi-ai service again.
+
+        :return: a ``display_notification`` client action that closes
+            the wizard
+        :rtype: dict
+        """
         self.ensure_one()
+        file_checksum = self._compute_mutasi_ai_file_checksum()
+        self._check_mutasi_ai_duplicate(file_checksum)
         attachment = (
             self.env["ir.attachment"]
             .sudo()
@@ -77,6 +104,74 @@ class AccountStatementImport(models.TransientModel):
             },
         }
 
+    def _compute_mutasi_ai_file_checksum(self):
+        """Compute the SHA-256 hex digest of the decoded uploaded file.
+
+        Matches exactly the ``Idempotency-Key`` value
+        ``AccountStatementImportMutasiAiBackend._call_service`` sends
+        to the mutasi-ai service for the same file content. Computed
+        independently here so a duplicate upload can be rejected
+        before any HTTP call is made.
+
+        :return: SHA-256 hex digest of ``self.statement_file`` decoded
+            from base64
+        :rtype: str
+        """
+        self.ensure_one()
+        data_file = base64.b64decode(self.statement_file or b"")
+        return hashlib.sha256(data_file).hexdigest()
+
+    def _check_mutasi_ai_duplicate(self, file_checksum):
+        """Reject re-uploading a file already handled by another job.
+
+        Searches for another
+        ``account.statement.import.mutasi.ai.job`` with the same
+        ``file_checksum`` whose ``state`` means the file was already
+        queued, processed, or successfully imported (``queued``,
+        ``processing``, ``done``, ``already_imported``). Jobs in
+        ``draft``, ``need_review``, or ``failed`` do not block, so a
+        re-upload after a failure remains possible. An empty
+        ``file_checksum`` never matches, so old jobs created before
+        this field existed are ignored.
+
+        :param file_checksum: SHA-256 hex digest of the uploaded file,
+            as returned by ``_compute_mutasi_ai_file_checksum``
+        :type file_checksum: str
+        :raises UserError: if a blocking duplicate job is found
+        """
+        self.ensure_one()
+        if not file_checksum:
+            return
+        duplicate_job = (
+            self.env["account.statement.import.mutasi.ai.job"]
+            .sudo()
+            .search(
+                [
+                    ("file_checksum", "=", file_checksum),
+                    (
+                        "state",
+                        "in",
+                        ("queued", "processing", "done", "already_imported"),
+                    ),
+                ],
+                limit=1,
+            )
+        )
+        if not duplicate_job:
+            return
+        error_message = (
+            _(
+                """
+Context: Enqueue mutasi-ai statement import
+Database ID: %s
+Problem: A file with the same content was already imported by job '%s'
+Solution: Check job '%s' instead of uploading the same file again
+"""
+            )
+            % (self.id, duplicate_job.name, duplicate_job.name)
+        )
+        raise UserError(error_message)
+
     def _prepare_mutasi_ai_attachment(self):
         self.ensure_one()
         return {
@@ -86,6 +181,17 @@ class AccountStatementImport(models.TransientModel):
         }
 
     def _prepare_mutasi_ai_job(self, attachment):
+        """Build the ``account.statement.import.mutasi.ai.job`` values.
+
+        Extension point: override to add fields to the job without
+        touching ``_enqueue_mutasi_ai_import``.
+
+        :param attachment: the ``ir.attachment`` already created for
+            the uploaded file
+        :type attachment: recordset of ``ir.attachment``
+        :return: dict of job values, including ``file_checksum``
+        :rtype: dict
+        """
         self.ensure_one()
         journal_id = self.env.context.get("journal_id")
         statement_id = False
@@ -99,4 +205,5 @@ class AccountStatementImport(models.TransientModel):
             "journal_id": journal_id,
             "statement_id": statement_id,
             "backend_id": self.mutasi_ai_backend_id.id,
+            "file_checksum": self._compute_mutasi_ai_file_checksum(),
         }

--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -49,6 +49,16 @@ class AccountStatementImportMutasiAiJob(models.Model):
         readonly=True,
         help="Original filename of the uploaded bank statement file.",
     )
+    file_checksum = fields.Char(
+        string="File Checksum",
+        readonly=True,
+        copy=False,
+        index=True,
+        help="SHA-256 hex digest of the decoded content of the uploaded "
+        "file. Used by the import wizard to reject re-uploading a file "
+        "that was already queued, processed, or successfully imported "
+        "by another job.",
+    )
     journal_id = fields.Many2one(
         string="Journal",
         comodel_name="account.journal",

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -2,6 +2,7 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import base64
+import hashlib
 from unittest.mock import Mock, patch
 
 from odoo.exceptions import AccessError, UserError
@@ -705,6 +706,170 @@ class TestImportMutasiAi(TransactionCase):
             )
         )
         self.assertEqual(form.mutasi_ai_backend_id, self.backend)
+
+    # ------------------------------------------------------------------
+    # file_checksum duplicate guard — pure Python (base64 fixtures)
+    # ------------------------------------------------------------------
+
+    def _make_job_with_checksum(self, file_checksum, state, filename="dup.pdf"):
+        """Create a job directly with a fixed ``file_checksum``/``state``.
+
+        Bypasses the wizard so the duplicate-guard tests can set up a
+        prior job in an arbitrary state without going through
+        ``_run()``.
+
+        :param file_checksum: value to store on ``file_checksum``
+        :type file_checksum: str
+        :param state: value to store on ``state``
+        :type state: str
+        :param filename: filename recorded on the job/attachment
+        :type filename: str
+        :return: the created job record
+        :rtype: recordset of ``account.statement.import.mutasi.ai.job``
+        """
+        attachment = self._make_attachment(filename)
+        return self.env[_JOB_MODEL].create(
+            {
+                "attachment_id": attachment.id,
+                "statement_filename": filename,
+                "backend_id": self.backend.id,
+                "file_checksum": file_checksum,
+                "state": state,
+            }
+        )
+
+    def test_enqueue_sets_file_checksum(self):
+        """Enqueueing a new file stores its SHA-256 hex digest.
+
+        Positive scenario — trigger P10 (L-09/L-10/L-11: the wizard's
+        ``statement_file`` is a binary field, so the fixture needs
+        ``base64``, which the YAML ``EVAL:`` whitelist does not allow).
+        """
+        content = b"file checksum positive test content"
+        wizard = self.env["account.statement.import"].create(
+            {
+                "statement_file": base64.b64encode(content),
+                "statement_filename": "checksum_new.pdf",
+                "mutasi_ai_backend_id": self.backend.id,
+            }
+        )
+        wizard.import_file_button()
+        job = self.env[_JOB_MODEL].search(
+            [("statement_filename", "=", "checksum_new.pdf")]
+        )
+        self.assertEqual(len(job), 1)
+        self.assertEqual(len(job.file_checksum), 64)
+        self.assertTrue(all(c in "0123456789abcdef" for c in job.file_checksum))
+
+    def test_enqueue_file_checksum_matches_sha256_of_content(self):
+        """The stored checksum equals SHA-256 of the decoded file.
+
+        Positive scenario — trigger P10 (L-09/L-10/L-11: same reasoning
+        as above; this also computes the expected digest with
+        ``hashlib``, unavailable to YAML ``EVAL:``). Confirms the value
+        is exactly the ``Idempotency-Key`` ``_call_service`` would send
+        for the same content.
+        """
+        content = b"file checksum equality test content"
+        expected = hashlib.sha256(content).hexdigest()
+        wizard = self.env["account.statement.import"].create(
+            {
+                "statement_file": base64.b64encode(content),
+                "statement_filename": "checksum_equal.pdf",
+                "mutasi_ai_backend_id": self.backend.id,
+            }
+        )
+        wizard.import_file_button()
+        job = self.env[_JOB_MODEL].search(
+            [("statement_filename", "=", "checksum_equal.pdf")]
+        )
+        self.assertEqual(job.file_checksum, expected)
+
+    def test_enqueue_duplicate_of_done_job_raises_and_creates_nothing(self):
+        """Re-uploading a file already ``done`` is rejected.
+
+        Negative scenario — trigger P10 (L-09/L-10/L-11: fixture needs
+        ``base64``). No new ``ir.attachment`` nor job record may be
+        created when the guard rejects the upload.
+        """
+        content = b"file checksum duplicate done test content"
+        checksum = hashlib.sha256(content).hexdigest()
+        previous_job = self._make_job_with_checksum(
+            checksum, "done", filename="dup_done_prev.pdf"
+        )
+        job_count_before = self.env[_JOB_MODEL].search_count([])
+        attachment_count_before = self.env["ir.attachment"].search_count([])
+        wizard = self.env["account.statement.import"].create(
+            {
+                "statement_file": base64.b64encode(content),
+                "statement_filename": "dup_done_new.pdf",
+                "mutasi_ai_backend_id": self.backend.id,
+            }
+        )
+        with self.assertRaises(UserError) as cm:
+            wizard.import_file_button()
+        self.assertIn(previous_job.name, str(cm.exception))
+        self.assertEqual(self.env[_JOB_MODEL].search_count([]), job_count_before)
+        self.assertEqual(
+            self.env["ir.attachment"].search_count([]), attachment_count_before
+        )
+
+    def test_enqueue_duplicate_of_failed_job_is_allowed(self):
+        """Re-uploading a file whose prior job ``failed`` is allowed.
+
+        Positive scenario — trigger P10 (L-09/L-10/L-11: fixture needs
+        ``base64``). A ``failed`` job must not block a retry-by-upload,
+        so a new job is created instead of raising.
+        """
+        content = b"file checksum duplicate failed test content"
+        checksum = hashlib.sha256(content).hexdigest()
+        self._make_job_with_checksum(checksum, "failed", filename="dup_failed_prev.pdf")
+        wizard = self.env["account.statement.import"].create(
+            {
+                "statement_file": base64.b64encode(content),
+                "statement_filename": "dup_failed_new.pdf",
+                "mutasi_ai_backend_id": self.backend.id,
+            }
+        )
+        wizard.import_file_button()
+        new_job = self.env[_JOB_MODEL].search(
+            [("statement_filename", "=", "dup_failed_new.pdf")]
+        )
+        self.assertEqual(len(new_job), 1)
+        self.assertEqual(new_job.file_checksum, checksum)
+
+    def test_enqueue_different_content_gets_different_checksums(self):
+        """Two files with different content get different checksums.
+
+        Positive scenario — trigger P10 (L-09/L-10/L-11: fixture needs
+        ``base64``). Neither upload raises, and the two jobs end up
+        with distinct ``file_checksum`` values.
+        """
+        wizard_a = self.env["account.statement.import"].create(
+            {
+                "statement_file": base64.b64encode(b"content variant A"),
+                "statement_filename": "distinct_a.pdf",
+                "mutasi_ai_backend_id": self.backend.id,
+            }
+        )
+        wizard_a.import_file_button()
+        wizard_b = self.env["account.statement.import"].create(
+            {
+                "statement_file": base64.b64encode(b"content variant B"),
+                "statement_filename": "distinct_b.pdf",
+                "mutasi_ai_backend_id": self.backend.id,
+            }
+        )
+        wizard_b.import_file_button()
+        job_a = self.env[_JOB_MODEL].search(
+            [("statement_filename", "=", "distinct_a.pdf")]
+        )
+        job_b = self.env[_JOB_MODEL].search(
+            [("statement_filename", "=", "distinct_b.pdf")]
+        )
+        self.assertEqual(len(job_a), 1)
+        self.assertEqual(len(job_b), 1)
+        self.assertNotEqual(job_a.file_checksum, job_b.file_checksum)
 
     # ------------------------------------------------------------------
     # Test Connection — mocked HTTP

--- a/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
+++ b/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
@@ -59,6 +59,7 @@
                     <group>
                         <field name="external_id" />
                         <field name="external_status" />
+                        <field name="file_checksum" />
                         <field name="statement_ids" widget="many2many_tags" />
                     </group>
                 </group>


### PR DESCRIPTION
## Ringkasan

Mencegah unggah ulang berkas identik menembus sampai layanan mutasi-ai (panggilan berbayar
dengan timeout sampai 600 detik) dengan menyimpan checksum SHA-256 pada job dan menolak
unggahan duplikat di wizard, sebelum `ir.attachment` maupun job dibuat.

- Field baru `file_checksum` (Char, readonly, copy=False, index=True) pada
  `account.statement.import.mutasi.ai.job`, diisi wizard di `_prepare_mutasi_ai_job()` via
  `_compute_mutasi_ai_file_checksum()` — nilainya persis sama dengan `Idempotency-Key` yang
  sudah dikirim `_call_service()` (dihitung terpisah).
- Guard `_check_mutasi_ai_duplicate()` pada wizard, dipanggil dari `_enqueue_mutasi_ai_import()`
  sebelum attachment/job dibuat. Menolak (UserError menyebut nama job sebelumnya) unggah
  berkas ber-checksum sama dengan job lain berstate `queued`/`processing`/`done`/
  `already_imported`; state `draft`/`need_review`/`failed` tidak diblokir. Checksum kosong
  diabaikan.
- `file_checksum` ditampilkan sebagai field readonly di form view job.
- Unit test Python murni (P10 — `statement_file` adalah field binary sehingga fixture-nya
  butuh `base64`, di luar whitelist `EVAL:` YAML, L-09 s.d. L-11).

Closes #110

## Test plan

- [x] `assets/verify-module.sh` — seluruh gate mekanis lolos kecuali docstring pre-existing
      (debt di luar ruang lingkup issue ini, tidak bertambah oleh perubahan ini)
- [x] `pre-commit run` lolos penuh saat commit
- [ ] CI GitHub (unit test dijalankan di CI, bukan lokal)