### PR TITLE
[FIX] ssi_account_statement_import_mutasi_ai

### DIFF
--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_backend.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_backend.py
@@ -207,7 +207,7 @@ Solution: Check the mutasi-ai service logs for the actual error
             statement_vals["balance_end_real"] = float(balance_end_real)
         return statement_vals
 
-    def _transform_result(self, result_json, filename):
+    def _transform_result(self, result_json, filename, file_checksum=None):
         """Convert a mutasi-ai ``StatementExtractionRead`` JSON body into
         the OCA ``account.statement.import`` triplet.
 
@@ -216,9 +216,23 @@ Solution: Check the mutasi-ai service logs for the actual error
         ``_prepare_bank_statement_vals`` (see its docstring for the
         ``balance_start``/``balance_end_real`` handling).
 
+        The fallback ``unique_import_id`` (used when the service omits
+        one) is keyed on ``file_checksum`` rather than ``filename``
+        when a checksum is given, so two differently-named files with
+        identical content collide on purpose (real duplicates) while
+        the same filename re-uploaded with different content does not
+        collide by accident. When ``file_checksum`` is empty/omitted,
+        the id falls back to the previous filename-based pattern, so
+        callers that do not have a checksum keep working unchanged.
+
         :param result_json: parsed JSON body returned by ``_call_service``
-        :param filename: original filename, used to build a fallback
-            ``unique_import_id`` when the service omits one
+        :param filename: original filename, used in error messages and
+            as the fallback ``unique_import_id`` basis when
+            ``file_checksum`` is empty/omitted
+        :param file_checksum: SHA-256 hex digest of the uploaded file
+            content, used as the fallback ``unique_import_id`` basis
+            when given
+        :type file_checksum: str or None
         :return: ``(currency_code, account_number, statements)`` triplet
         :rtype: tuple
         :raises UserError: if the extraction failed, no currency can be
@@ -283,9 +297,21 @@ Solution: Check the source file quality (scan/photo legibility) and retry
                         % (self.id,)
                     )
                     raise UserError(error_message)
-                unique_import_id = source_tx.get(
-                    "unique_import_id"
-                ) or "mutasi-ai-%s-%s-%s" % (filename, st_idx, tx_idx)
+                if file_checksum:
+                    fallback_unique_import_id = "mutasi-ai-%s-%s-%s" % (
+                        file_checksum,
+                        st_idx,
+                        tx_idx,
+                    )
+                else:
+                    fallback_unique_import_id = "mutasi-ai-%s-%s-%s" % (
+                        filename,
+                        st_idx,
+                        tx_idx,
+                    )
+                unique_import_id = (
+                    source_tx.get("unique_import_id") or fallback_unique_import_id
+                )
                 transactions.append(
                     {
                         "payment_ref": source_tx.get("payment_ref") or "/",

--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -276,7 +276,9 @@ Solution: Wait for the current job to finish, or check its result
 
             response_json = self.backend_id._call_service(data_file, filename)
             external_status = response_json.get("status")
-            triplet = self.backend_id._transform_result(response_json, filename)
+            triplet = self.backend_id._transform_result(
+                response_json, filename, file_checksum=self.file_checksum
+            )
 
             import_context = {}
             if self.journal_id:

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -158,6 +158,107 @@ class TestImportMutasiAi(TransactionCase):
         )
         self.assertTrue(statements[0]["transactions"][0]["unique_import_id"])
 
+    def test_transform_result_fallback_uses_checksum_not_filename(self):
+        """A checksum-based fallback id contains the checksum, not the name.
+
+        Positive scenario — trigger P1 (L-01/L-02: what is asserted is
+        the bare tuple returned by ``_transform_result``, not a record
+        field YAML's ``assert`` could ``getattr``).
+        """
+        response = _sample_response()
+        response["result"]["statements"][0]["transactions"][0][
+            "unique_import_id"
+        ] = None
+        _currency, _account, statements = self.backend._transform_result(
+            response, "statement.pdf", file_checksum="abc123checksum"
+        )
+        fallback_id = statements[0]["transactions"][0]["unique_import_id"]
+        self.assertIn("abc123checksum", fallback_id)
+        self.assertNotIn("statement.pdf", fallback_id)
+
+    def test_transform_result_fallback_same_checksum_different_filenames(self):
+        """Different filenames with the same checksum collide on purpose.
+
+        Positive scenario — trigger P1 (L-01/L-02: same reasoning as
+        above, the return value is a bare tuple).
+        """
+        response_a = _sample_response()
+        response_a["result"]["statements"][0]["transactions"][0][
+            "unique_import_id"
+        ] = None
+        response_b = _sample_response()
+        response_b["result"]["statements"][0]["transactions"][0][
+            "unique_import_id"
+        ] = None
+        _c1, _a1, statements_a = self.backend._transform_result(
+            response_a, "january.pdf", file_checksum="same-checksum"
+        )
+        _c2, _a2, statements_b = self.backend._transform_result(
+            response_b, "february.pdf", file_checksum="same-checksum"
+        )
+        self.assertEqual(
+            statements_a[0]["transactions"][0]["unique_import_id"],
+            statements_b[0]["transactions"][0]["unique_import_id"],
+        )
+
+    def test_transform_result_fallback_same_filename_different_checksums(self):
+        """The same filename with different checksums does not collide.
+
+        Positive scenario — trigger P1 (L-01/L-02: same reasoning as
+        above, the return value is a bare tuple).
+        """
+        response_a = _sample_response()
+        response_a["result"]["statements"][0]["transactions"][0][
+            "unique_import_id"
+        ] = None
+        response_b = _sample_response()
+        response_b["result"]["statements"][0]["transactions"][0][
+            "unique_import_id"
+        ] = None
+        _c1, _a1, statements_a = self.backend._transform_result(
+            response_a, "statement.pdf", file_checksum="checksum-one"
+        )
+        _c2, _a2, statements_b = self.backend._transform_result(
+            response_b, "statement.pdf", file_checksum="checksum-two"
+        )
+        self.assertNotEqual(
+            statements_a[0]["transactions"][0]["unique_import_id"],
+            statements_b[0]["transactions"][0]["unique_import_id"],
+        )
+
+    def test_transform_result_fallback_without_checksum_uses_filename(self):
+        """Omitting ``file_checksum`` keeps the old filename-based id.
+
+        Positive scenario — trigger P1 (L-01/L-02: same reasoning as
+        above, the return value is a bare tuple).
+        """
+        response = _sample_response()
+        response["result"]["statements"][0]["transactions"][0][
+            "unique_import_id"
+        ] = None
+        _currency, _account, statements = self.backend._transform_result(
+            response, "statement.pdf"
+        )
+        fallback_id = statements[0]["transactions"][0]["unique_import_id"]
+        self.assertIn("statement.pdf", fallback_id)
+
+    def test_transform_result_keeps_service_provided_unique_import_id(self):
+        """A service-provided ``unique_import_id`` wins over the checksum.
+
+        Positive scenario — trigger P1 (L-01/L-02: same reasoning as
+        above, the return value is a bare tuple).
+        """
+        response = _sample_response()
+        provided_id = response["result"]["statements"][0]["transactions"][0][
+            "unique_import_id"
+        ]
+        _currency, _account, statements = self.backend._transform_result(
+            response, "statement.pdf", file_checksum="should-be-ignored"
+        )
+        actual_id = statements[0]["transactions"][0]["unique_import_id"]
+        self.assertEqual(actual_id, provided_id)
+        self.assertNotIn("should-be-ignored", actual_id)
+
     def test_transform_result_failed_status_raises(self):
         response = _sample_response(status="failed")
         response["error"] = "Could not read the file"
@@ -479,6 +580,36 @@ class TestImportMutasiAi(TransactionCase):
         self.assertEqual(job.state, "need_review")
         self.assertEqual(job.external_status, "need_review")
         self.assertTrue(job.statement_ids)
+
+    def test_run_uses_checksum_based_unique_import_id(self):
+        """A full job run stores a checksum-based ``unique_import_id``.
+
+        Positive scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; ``odoo-yaml-test`` has no
+        mock/patch support). ``_run`` must pass the job's own
+        ``file_checksum`` through to ``_transform_result``, so the
+        resulting statement line's ``unique_import_id`` is built from
+        the checksum rather than the filename.
+        """
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        response = _sample_response(
+            unique_suffix="checksum-run", currency_code=self.company_currency
+        )
+        response["result"]["statements"][0]["transactions"][0][
+            "unique_import_id"
+        ] = None
+        job = self._make_job(unique_suffix="checksum-run")
+        job.write({"file_checksum": "run-checksum-value"})
+        with patch(_CALL_SERVICE_PATH, return_value=response):
+            job._run()
+        self.assertEqual(job.state, "done")
+        line = self.env["account.bank.statement.line"].search(
+            [("payment_ref", "=", "TRANSFER MASUK"), ("amount", "=", 500000.0)]
+        )
+        self.assertEqual(len(line), 1)
+        self.assertIn("run-checksum-value", line.unique_import_id)
+        self.assertNotIn("statement.pdf", line.unique_import_id)
 
     def test_run_error_path_sets_failed(self):
         job = self._make_job(unique_suffix="error")


### PR DESCRIPTION
## Ringkasan

Mengganti basis pembentukan `unique_import_id` cadangan pada `_transform_result()`
dari nama berkas menjadi checksum berkas (`file_checksum`), sesuai issue #111.

- `_transform_result()` menerima parameter opsional `file_checksum=None`; bila
  terisi, id cadangan memakai pola `mutasi-ai-<checksum>-<idx_statement>-<idx_tx>`
  dan tidak lagi memuat nama berkas. Bila kosong/tidak diberikan, tetap memakai
  pola lama berbasis nama berkas (backward compatible).
- `unique_import_id` yang disediakan layanan mutasi-ai tetap dipakai apa adanya;
  checksum diabaikan pada jalur itu.
- `_run()` pada `account.statement.import.mutasi.ai.job` meneruskan
  `self.file_checksum` (field dari issue prasyarat #110) ke `_transform_result()`.
- Tidak ada script migrasi — baris statement yang sudah pernah diimpor tetap
  memakai id lama; risiko impor ulang berkas identik pra-perubahan sudah ditutup
  guard checksum dari #110.

## Test plan

- [x] Unit test Python murni (P1) untuk pola id checksum, tabrakan disengaja pada
      nama berkas berbeda + checksum sama, non-tabrakan pada nama berkas sama +
      checksum berbeda, fallback ke nama berkas saat checksum kosong, dan
      `unique_import_id` dari layanan tetap menang atas checksum.
- [x] Unit test Python murni (P6, mock `_call_service`) untuk end-to-end job run
      yang memverifikasi baris statement tercipta memakai id berbasis checksum.
- [x] `pre-commit` lolos di commit.
- [ ] CI GitHub (menyusul setelah PR ini dibuka).

Closes #111