### PR TITLE
[UPD] ssi_account_statement_import_mutasi_ai: pulihkan job Mutasi AI yang tersangkut di state queued

### DIFF
--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -4,11 +4,17 @@
 import base64
 import json
 import logging
+from datetime import timedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
+
+# Extra grace period, on top of the backend's own `timeout_seconds`, before
+# a `queued` job whose `queue_job_id` is still `started` is considered
+# orphaned by a dead worker (see `_compute_retry_ok`).
+_STUCK_JOB_MARGIN = timedelta(seconds=300)
 
 
 class AccountStatementImportMutasiAiJob(models.Model):
@@ -158,6 +164,88 @@ class AccountStatementImportMutasiAiJob(models.Model):
         "they had already been imported. Empty when the wizard reported "
         "nothing noteworthy.",
     )
+    queue_job_id = fields.Many2one(
+        string="Queue Job",
+        comodel_name="queue.job",
+        readonly=True,
+        copy=False,
+        ondelete="set null",
+        help="Background queue_job record running this job's ``_run()``. "
+        "Set when the job is enqueued via ``_enqueue()``. Used to tell "
+        "whether a 'Queued' job whose worker died is safe to retry.",
+    )
+    retry_ok = fields.Boolean(
+        string="Retry Allowed",
+        compute="_compute_retry_ok",
+        compute_sudo=True,
+        help="Technical field telling whether the Retry button/action "
+        "may run right now. True for 'Failed' and 'Need Review' jobs, "
+        "and for 'Queued' jobs whose background queue_job is missing, "
+        "already finished, or has been running past the backend's "
+        "configured timeout — all signs that the worker that was "
+        "supposed to process it has died, leaving the job stuck.",
+    )
+
+    @api.depends(
+        "state",
+        "queue_job_id.state",
+        "queue_job_id.date_started",
+        "queue_job_id.date_enqueued",
+        "queue_job_id.create_date",
+        "backend_id.timeout_seconds",
+    )
+    def _compute_retry_ok(self):
+        """Decide whether the Retry action is currently allowed.
+
+        See the module's backlog issue #114 for the four rules this
+        implements: a job can be retried when it is ``failed`` or
+        ``need_review``, or when it is ``queued`` but its paired
+        ``queue_job_id`` shows the background worker is no longer (or
+        never was) actually running it.
+        """
+        now = fields.Datetime.now()
+        for record in self:
+            result = False
+            if record.state in ("failed", "need_review"):
+                result = True
+            elif record.state == "queued":
+                result = record._queued_retry_ok(now)
+            record.retry_ok = result
+
+    def _queued_retry_ok(self, now):
+        """Return whether a ``queued`` job's background job looks dead.
+
+        :param now: current datetime, injected so the whole record set
+            computed together compares against the same instant
+        :type now: datetime.datetime
+        :return: ``True`` when ``queue_job_id`` is empty, already
+            finished (``done``/``failed``/``cancelled``), or still
+            "running" (``wait_dependencies``/``pending``/``enqueued``/
+            ``started``) well past ``backend_id.timeout_seconds``
+        :rtype: bool
+        """
+        self.ensure_one()
+        queue_job = self.queue_job_id
+        if not queue_job:
+            return True
+        if queue_job.state in ("done", "failed", "cancelled"):
+            return True
+        if queue_job.state in (
+            "wait_dependencies",
+            "pending",
+            "enqueued",
+            "started",
+        ):
+            started_at = (
+                queue_job.date_started
+                or queue_job.date_enqueued
+                or queue_job.create_date
+            )
+            if not started_at:
+                return False
+            timeout = timedelta(seconds=self.backend_id.timeout_seconds)
+            return now - started_at > timeout + _STUCK_JOB_MARGIN
+        return False
 
     @api.model
     def create(self, vals):
@@ -175,26 +263,39 @@ class AccountStatementImportMutasiAiJob(models.Model):
             record._enqueue()
 
     def _enqueue(self):
+        """Move this job to ``queued`` and delay its ``_run()``.
+
+        Stores the resulting ``queue.job`` record on ``queue_job_id``
+        (via ``Job.db_record()``) so ``_compute_retry_ok`` can later
+        tell whether the background worker is still alive.
+        """
         self.ensure_one()
         self.write({"state": "queued", "error_message": False})
-        self.with_delay(
+        delayable_job = self.with_delay(
             description=_("Import bank statement via mutasi-ai: %s")
             % (self.statement_filename or self.name)
         )._run()
+        self.write({"queue_job_id": delayable_job.db_record().id})
 
     def action_retry(self):
         for record in self.sudo():
             record._retry()
 
     def _retry(self):
+        """Re-enqueue this job, raising when ``retry_ok`` is false.
+
+        :raises UserError: when ``retry_ok`` is false, i.e. the job is
+            neither ``failed``/``need_review`` nor a ``queued`` job
+            whose background ``queue_job_id`` looks dead
+        """
         self.ensure_one()
-        if self.state not in ("failed", "need_review"):
+        if not self.retry_ok:
             error_message = (
                 _(
                     """
 Context: Retry mutasi-ai statement import job
 Database ID: %s
-Problem: Job is in state '%s', only 'Failed' or 'Need Review' jobs can be retried
+Problem: Job is in state '%s' and cannot be retried right now
 Solution: Wait for the current job to finish, or check its result
 """
                 )

--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -191,7 +191,7 @@ class AccountStatementImportMutasiAiJob(models.Model):
         "queue_job_id.state",
         "queue_job_id.date_started",
         "queue_job_id.date_enqueued",
-        "queue_job_id.create_date",
+        "queue_job_id.date_created",
         "backend_id.timeout_seconds",
     )
     def _compute_retry_ok(self):
@@ -239,7 +239,7 @@ class AccountStatementImportMutasiAiJob(models.Model):
             started_at = (
                 queue_job.date_started
                 or queue_job.date_enqueued
-                or queue_job.create_date
+                or queue_job.date_created
             )
             if not started_at:
                 return False

--- a/ssi_account_statement_import_mutasi_ai/tests/__init__.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/__init__.py
@@ -4,3 +4,4 @@
 from . import test_mutasi_ai_backend
 from . import test_import_mutasi_ai
 from . import test_account_statement_import_mutasi_ai_job_state
+from . import test_account_statement_import_mutasi_ai_job_retry_ok

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_retry_ok.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_retry_ok.py
@@ -1,0 +1,17 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountStatementImportMutasiAiJobRetryOk(YamlTransactionCase):
+    """Scenario tests for the job ``retry_ok`` compute and ``_retry()``."""
+
+    def test_account_statement_import_mutasi_ai_job_retry_ok(self):
+        """Run the ``retry_ok``/``action_retry`` scenarios."""
+        self.run_yaml_scenario(
+            "test_account_statement_import_mutasi_ai_job_retry_ok.yaml"
+        )

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_retry_ok.yaml
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_retry_ok.yaml
@@ -17,7 +17,7 @@ setup:
       save_as: "backend"
       values:
         name: "Retry Ok Test Backend"
-        code: "RETRY-OK-BACKEND"
+        code: "EVAL: 'RETRY-OK-BACKEND-%d' % registry['attachment'].id"
         base_url: "https://carik.example.com"
         bearer_token: "test-token"
         timeout_seconds: 600

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_retry_ok.yaml
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_retry_ok.yaml
@@ -1,0 +1,240 @@
+options:
+  auto_refresh: true
+
+setup:
+  steps:
+    - step: "Create statement attachment"
+      action: "create"
+      model: "ir.attachment"
+      save_as: "attachment"
+      values:
+        name: "statement.pdf"
+        datas: "ZHVtbXkgcGRmIGNvbnRlbnQ="
+        type: "binary"
+    - step: "Create mutasi-ai backend"
+      action: "create"
+      model: "account.statement.import.mutasi.ai.backend"
+      save_as: "backend"
+      values:
+        name: "Retry Ok Test Backend"
+        code: "RETRY-OK-BACKEND"
+        base_url: "https://carik.example.com"
+        bearer_token: "test-token"
+        timeout_seconds: 600
+
+scenarios:
+  - name: "retry_ok is true for a failed job"
+    steps:
+      - step: "Create failed job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+          state: "failed"
+      - step: "Assert retry_ok is true"
+        action: "assert"
+        target: "job"
+        asserts:
+          retry_ok:
+            type: "value"
+            expected: true
+
+  - name: "retry_ok is true for a need_review job"
+    steps:
+      - step: "Create need_review job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+          state: "need_review"
+      - step: "Assert retry_ok is true"
+        action: "assert"
+        target: "job"
+        asserts:
+          retry_ok:
+            type: "value"
+            expected: true
+
+  - name: "retry_ok is true for already_imported is false"
+    steps:
+      - step: "Create already_imported job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+          state: "already_imported"
+      - step: "Assert retry_ok is false"
+        action: "assert"
+        target: "job"
+        asserts:
+          retry_ok:
+            type: "value"
+            expected: false
+
+  - name: "retry_ok is true for a queued job without a queue_job_id"
+    steps:
+      - step: "Create queued job without a paired queue.job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+          state: "queued"
+      - step: "Assert retry_ok is true"
+        action: "assert"
+        target: "job"
+        asserts:
+          retry_ok:
+            type: "value"
+            expected: true
+          queue_job_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "retry_ok is true for a queued job whose queue.job is done"
+    steps:
+      - step: "Create job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+      - step: "Enqueue the job, creating a real paired queue.job"
+        action: "call"
+        target: "job"
+        method: "action_enqueue"
+      - step: "Locate the paired queue.job record"
+        action: "search"
+        model: "queue.job"
+        domain: [["id", "=", "REC: job.queue_job_id.id"]]
+        save_as: "qjob"
+      - step: "Force the paired queue.job to done"
+        action: "write"
+        target: "qjob"
+        values:
+          state: "done"
+      - step: "Assert retry_ok is true"
+        action: "assert"
+        target: "job"
+        asserts:
+          state:
+            type: "value"
+            expected: "queued"
+          retry_ok:
+            type: "value"
+            expected: true
+
+  - name:
+      "retry_ok is true for a queued job whose started queue.job is past the timeout"
+    steps:
+      - step: "Create job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+      - step: "Enqueue the job, creating a real paired queue.job"
+        action: "call"
+        target: "job"
+        method: "action_enqueue"
+      - step: "Locate the paired queue.job record"
+        action: "search"
+        model: "queue.job"
+        domain: [["id", "=", "REC: job.queue_job_id.id"]]
+        save_as: "qjob"
+      - step: "Mark the paired queue.job started long ago"
+        action: "write"
+        target: "qjob"
+        values:
+          state: "started"
+          date_started: "EVAL: datetime.now() - timedelta(days=1)"
+      - step: "Assert retry_ok is true"
+        action: "assert"
+        target: "job"
+        asserts:
+          retry_ok:
+            type: "value"
+            expected: true
+
+  - name: "retry_ok is false for a queued job whose started queue.job is fresh"
+    steps:
+      - step: "Create job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+      - step: "Enqueue the job, creating a real paired queue.job"
+        action: "call"
+        target: "job"
+        method: "action_enqueue"
+      - step: "Locate the paired queue.job record"
+        action: "search"
+        model: "queue.job"
+        domain: [["id", "=", "REC: job.queue_job_id.id"]]
+        save_as: "qjob"
+      - step: "Mark the paired queue.job started just now"
+        action: "write"
+        target: "qjob"
+        values:
+          state: "started"
+          date_started: "EVAL: datetime.now()"
+      - step: "Assert retry_ok is false"
+        action: "assert"
+        target: "job"
+        asserts:
+          retry_ok:
+            type: "value"
+            expected: false
+
+  - name: "action_retry recovers an orphaned queued job"
+    steps:
+      - step: "Create an orphaned queued job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+          state: "queued"
+      - step: "Retry the orphaned job"
+        action: "call"
+        target: "job"
+        method: "action_retry"
+      - step: "Assert the job is queued again with no error"
+        action: "assert"
+        target: "job"
+        asserts:
+          state:
+            type: "value"
+            expected: "queued"
+          error_message:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "action_retry is rejected on a done job"
+    steps:
+      - step: "Create a done job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+          state: "done"
+      - step: "Retry on a done job must be rejected"
+        action: "call"
+        target: "job"
+        method: "action_retry"
+        expect_error:
+          type: "UserError"

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -826,6 +826,22 @@ class TestImportMutasiAi(TransactionCase):
         self.assertEqual(len(job), 1)
         self.assertFalse(job.statement_id)
 
+    def test_enqueue_links_queue_job_id(self):
+        """``_enqueue()`` stores the ``queue.job`` it just created.
+
+        Positive scenario — trigger P1 (L-01: the interesting value is
+        the intermediate ``Job`` returned by ``with_delay()._run()``,
+        exposed on the record only via ``queue_job_id`` after
+        ``_enqueue()`` writes it; YAML's ``call`` action discards
+        method return values, so only calling ``_enqueue()`` directly
+        in Python can pin the model/method it links to).
+        """
+        job = self._make_job(unique_suffix="link-queue-job")
+        job._enqueue()
+        self.assertTrue(job.queue_job_id)
+        self.assertEqual(job.queue_job_id.model_name, _JOB_MODEL)
+        self.assertEqual(job.queue_job_id.method_name, "_run")
+
     def test_preselect_backend_from_journal_default(self):
         if not self.bank_journal:
             self.skipTest("No bank journal found in test environment")

--- a/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
+++ b/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
@@ -36,7 +36,7 @@
                         type="object"
                         string="Retry"
                         class="btn-primary"
-                        attrs="{'invisible': [('state', 'not in', ('failed', 'need_review'))]}"
+                        attrs="{'invisible': [('retry_ok', '=', False)]}"
                     />
                 <button
                         name="action_open_statements"
@@ -48,6 +48,7 @@
                 <field name="state" widget="statusbar" />
             </header>
             <sheet>
+                <field name="retry_ok" invisible="1" />
                 <group>
                     <group>
                         <field name="name" />
@@ -55,6 +56,7 @@
                         <field name="journal_id" />
                         <field name="statement_id" />
                         <field name="backend_id" />
+                        <field name="queue_job_id" />
                     </group>
                     <group>
                         <field name="external_id" />


### PR DESCRIPTION
## Ringkasan

- Tambah field `queue_job_id` (Many2one ke `queue.job`) yang diisi saat `_enqueue()` memanggil `with_delay()`, sehingga job punya rujukan ke pekerjaan latarnya.
- Tambah field compute `retry_ok` yang menandai job boleh di-retry: benar untuk `state` `failed`/`need_review`, dan untuk `state` `queued` bila `queue_job_id` kosong, sudah selesai (`done`/`failed`/`cancelled`), atau masih "berjalan" tapi sudah melewati `timeout_seconds` backend + margin 300 detik — tanda pekerjaan latarnya mati tanpa sempat memperbarui job.
- `_retry()` kini memeriksa `retry_ok`, bukan daftar state tetap, sehingga job yang tersangkut di state `queued` karena worker terbunuh (`limit_time_real` `queue_job`) bisa dipulihkan lewat tombol Retry tanpa membuka peluang duplikasi ekstraksi selagi pekerjaan aslinya masih hidup.
- Tombol Retry di form job memakai `attrs` berbasis `retry_ok`; `queue_job_id` ditampilkan di form agar operator bisa menelusuri pekerjaan latarnya.

## Test plan

- [x] Unit test YAML `retry_ok`/`action_retry` (9 skenario, lihat `tests/test_account_statement_import_mutasi_ai_job_retry_ok.yaml`)
- [x] Unit test Python murni untuk penautan `queue_job_id` oleh `_enqueue()` (P1/L-01)
- [x] CI GitHub (unit test dijalankan di CI, bukan lokal)

Closes #114