### PR TITLE
[UPD] ssi_account_statement_import_mutasi_ai: sediakan menu & action job Mutasi AI

### DIFF
--- a/ssi_account_statement_import_mutasi_ai/tests/__init__.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_mutasi_ai_backend
 from . import test_import_mutasi_ai
 from . import test_account_statement_import_mutasi_ai_job_state
 from . import test_account_statement_import_mutasi_ai_job_retry_ok
+from . import test_account_statement_import_mutasi_ai_job_menu

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_menu.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_menu.py
@@ -1,0 +1,15 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountStatementImportMutasiAiJobMenu(YamlTransactionCase):
+    """Field-only scenario tests for the job window action & menuitem."""
+
+    def test_account_statement_import_mutasi_ai_job_menu(self):
+        """Run the window action / menuitem data-loading scenarios."""
+        self.run_yaml_scenario("test_account_statement_import_mutasi_ai_job_menu.yaml")

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_menu.yaml
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_menu.yaml
@@ -1,0 +1,73 @@
+scenarios:
+  - name: "Job window action has the expected res_model and view_mode"
+    steps:
+      - step: "Get job window action"
+        action: "ref"
+        xml_id: "ssi_account_statement_import_mutasi_ai.account_statement_import_mutasi_ai_job_action"
+        save_as: "job_action"
+      - step: "Assert res_model and view_mode"
+        action: "assert"
+        target: "job_action"
+        asserts:
+          res_model:
+            type: "value"
+            expected: "account.statement.import.mutasi.ai.job"
+          view_mode:
+            type: "value"
+            expected: "tree,form"
+
+  - name: "Job menuitem points to the job window action"
+    steps:
+      - step: "Get job window action"
+        action: "ref"
+        xml_id: "ssi_account_statement_import_mutasi_ai.account_statement_import_mutasi_ai_job_action"
+        save_as: "job_action"
+      - step: "Get job menuitem"
+        action: "ref"
+        xml_id: "ssi_account_statement_import_mutasi_ai.menu_account_statement_import_mutasi_ai_job"
+        save_as: "job_menu"
+      - step: "Assert menuitem action"
+        action: "assert"
+        target: "job_menu"
+        asserts:
+          action:
+            type: "m2o"
+            expected: "REC: job_action"
+
+  - name: "Job menuitem is placed under Bank & Cash"
+    steps:
+      - step: "Get job menuitem"
+        action: "ref"
+        xml_id: "ssi_account_statement_import_mutasi_ai.menu_account_statement_import_mutasi_ai_job"
+        save_as: "job_menu"
+      - step: "Get Bank & Cash menu"
+        action: "ref"
+        xml_id: "ssi_financial_accounting.menu_bank_cash"
+        save_as: "bank_cash_menu"
+      - step: "Assert menuitem parent"
+        action: "assert"
+        target: "job_menu"
+        asserts:
+          parent_id:
+            type: "m2o"
+            expected: "REC: bank_cash_menu"
+
+  - name: "Job menuitem is restricted to the bank statement user group"
+    steps:
+      - step: "Get job menuitem"
+        action: "ref"
+        xml_id: "ssi_account_statement_import_mutasi_ai.menu_account_statement_import_mutasi_ai_job"
+        save_as: "job_menu"
+      - step: "Get bank statement user group"
+        action: "ref"
+        xml_id: "ssi_financial_accounting.bank_statement_user_group"
+        save_as: "bank_statement_user_group"
+      - step: "Assert menuitem groups_id contains the bank statement group"
+        action: "assert"
+        target: "job_menu"
+        asserts:
+          groups_id:
+            type: "m2m"
+            check: "contains"
+            expected_records:
+              - "REC: bank_statement_user_group"

--- a/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
+++ b/ssi_account_statement_import_mutasi_ai/views/account_statement_import_mutasi_ai_job_views.xml
@@ -80,4 +80,23 @@
         </form>
     </field>
 </record>
+
+<record
+        id="account_statement_import_mutasi_ai_job_action"
+        model="ir.actions.act_window"
+    >
+    <field name="name">Mutasi AI Import Jobs</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">account.statement.import.mutasi.ai.job</field>
+    <field name="view_mode">tree,form</field>
+</record>
+
+<menuitem
+        id="menu_account_statement_import_mutasi_ai_job"
+        name="Mutasi AI Import Jobs"
+        parent="ssi_financial_accounting.menu_bank_cash"
+        action="account_statement_import_mutasi_ai_job_action"
+        groups="ssi_financial_accounting.bank_statement_user_group"
+        sequence="3"
+    />
 </odoo>


### PR DESCRIPTION
## Summary

- Tambah window action untuk model `account.statement.import.mutasi.ai.job` (tree,form).
- Tambah menuitem di bawah menu Bank & Cash (`ssi_financial_accounting.menu_bank_cash`)
  yang menunjuk action tersebut, dibatasi grup `bank_statement_user_group`, sehingga
  pengguna bisa membuka daftar job Mutasi AI dan menekan tombol Retry yang sudah ada
  di form job.
- Tambah unit test `odoo-yaml-test` yang memverifikasi `res_model`/`view_mode` action,
  serta `action`/`parent_id`/`groups_id` menuitem.

## Test plan

- [x] Unit test YAML baru (`test_account_statement_import_mutasi_ai_job_menu.yaml`)
      dijalankan di CI GitHub.
- [x] Tidak ada test/assertion yang dihapus atau dilonggarkan.

Closes open-synergy/ssi-financial-accounting#113