### PR TITLE
[UPD] ssi_account_statement_import_mutasi_ai: tautkan job Mutasi AI ke statement sejak dibuat

### DIFF
--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -414,9 +414,14 @@ Solution: Wait for the current job to finish, or check its result
                 # Mirrors the context the base wizard normally receives when
                 # opened from an existing statement's "Import Statement"
                 # button, so `import_single_statement` updates it instead
-                # of creating a new one.
+                # of creating a new one. `journal_id` is set from the
+                # target statement's own journal (like
+                # `AccountBankStatement.action_import_statement` does) so
+                # `_match_journal` resolves it even when the file's
+                # account number doesn't match any journal's bank account.
                 import_context["active_model"] = "account.bank.statement"
                 import_context["active_ids"] = [self.statement_id.id]
+                import_context["journal_id"] = self.statement_id.journal_id.id
             wizard = (
                 self.env["account.statement.import"]
                 .sudo()

--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -249,6 +249,21 @@ class AccountStatementImportMutasiAiJob(models.Model):
 
     @api.model
     def create(self, vals):
+        """Create a job, linking it to its target statement immediately.
+
+        Assigns a sequence-based ``name`` when the caller did not
+        supply one. When ``vals`` carries a ``statement_id`` (the job
+        targets an existing bank statement), that statement is also
+        linked on ``statement_ids`` right away, so the statement's
+        ``mutasi_ai_job_ids`` shows the job from the moment it is
+        created — before ``_run()`` (queued/processing/failed jobs are
+        otherwise invisible on the statement they target).
+
+        :param vals: field values for the new record
+        :type vals: dict
+        :return: the newly created job record
+        :rtype: recordset of ``account.statement.import.mutasi.ai.job``
+        """
         if vals.get("name", "New") in (False, "New"):
             vals["name"] = (
                 self.env["ir.sequence"].next_by_code(
@@ -256,6 +271,10 @@ class AccountStatementImportMutasiAiJob(models.Model):
                 )
                 or "New"
             )
+        if vals.get("statement_id"):
+            vals["statement_ids"] = (vals.get("statement_ids") or []) + [
+                (4, vals["statement_id"])
+            ]
         return super().create(vals)
 
     def action_enqueue(self):
@@ -369,6 +388,13 @@ Solution: Wait for the current job to finish, or check its result
         failure is caught and recorded on ``state`` / ``error_message`` so
         the job can be inspected and retried from the UI, instead of
         relying on queue_job's own retry/failure handling.
+
+        ``statement_ids`` is updated with link (``4``) commands for
+        every id in ``result["statement_ids"]`` rather than a
+        replace-all (``6``) command, so a run whose file is fully
+        duplicate (``result["statement_ids"]`` empty) never severs the
+        link this job's ``create()`` already made to its target
+        ``statement_id``.
         """
         self.ensure_one()
         try:
@@ -420,7 +446,9 @@ Solution: Wait for the current job to finish, or check its result
                     "external_id": response_json.get("id"),
                     "external_status": external_status,
                     "response_json": json.dumps(response_json),
-                    "statement_ids": [(6, 0, result["statement_ids"])],
+                    "statement_ids": [
+                        (4, statement_id) for statement_id in result["statement_ids"]
+                    ],
                     "error_message": False,
                     "notification_message": self._prepare_notification_message(result),
                 }

--- a/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
+++ b/ssi_account_statement_import_mutasi_ai/models/account_statement_import_mutasi_ai_job.py
@@ -414,14 +414,9 @@ Solution: Wait for the current job to finish, or check its result
                 # Mirrors the context the base wizard normally receives when
                 # opened from an existing statement's "Import Statement"
                 # button, so `import_single_statement` updates it instead
-                # of creating a new one. `journal_id` is set from the
-                # target statement's own journal (like
-                # `AccountBankStatement.action_import_statement` does) so
-                # `_match_journal` resolves it even when the file's
-                # account number doesn't match any journal's bank account.
+                # of creating a new one.
                 import_context["active_model"] = "account.bank.statement"
                 import_context["active_ids"] = [self.statement_id.id]
-                import_context["journal_id"] = self.statement_id.journal_id.id
             wizard = (
                 self.env["account.statement.import"]
                 .sudo()

--- a/ssi_account_statement_import_mutasi_ai/tests/__init__.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_import_mutasi_ai
 from . import test_account_statement_import_mutasi_ai_job_state
 from . import test_account_statement_import_mutasi_ai_job_retry_ok
 from . import test_account_statement_import_mutasi_ai_job_menu
+from . import test_account_statement_import_mutasi_ai_job_statement_link

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_statement_link.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_statement_link.py
@@ -1,0 +1,17 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountStatementImportMutasiAiJobStatementLink(YamlTransactionCase):
+    """Scenario tests for statement linking at job ``create()``."""
+
+    def test_account_statement_import_mutasi_ai_job_statement_link(self):
+        """Run the create()-time statement linking scenarios."""
+        self.run_yaml_scenario(
+            "test_account_statement_import_mutasi_ai_job_statement_link.yaml"
+        )

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_statement_link.yaml
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_statement_link.yaml
@@ -1,0 +1,86 @@
+scenarios:
+  - name: "Job created with statement_id is linked to that statement"
+    steps:
+      - step: "Search for an existing bank journal"
+        action: "search"
+        model: "account.journal"
+        save_as: "bank_journal"
+        domain:
+          - ["type", "in", ["cash", "bank"]]
+        limit: 1
+      - step: "Create the target bank statement"
+        action: "create"
+        model: "account.bank.statement"
+        save_as: "target_statement"
+        values:
+          journal_id: "REC: bank_journal.id"
+          date: "2026-01-31"
+      - step: "Create statement attachment"
+        action: "create"
+        model: "ir.attachment"
+        save_as: "attachment"
+        values:
+          name: "statement.pdf"
+          datas: "ZHVtbXkgcGRmIGNvbnRlbnQ="
+          type: "binary"
+      - step: "Create mutasi-ai backend"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.backend"
+        save_as: "backend"
+        values:
+          name: "Statement Link Test Backend"
+          code: "STMT-LINK-BACKEND-1"
+          base_url: "https://carik.example.com"
+          bearer_token: "test-token"
+      - step: "Create job targeting the existing statement"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+          statement_id: "REC: target_statement.id"
+      - step: "Assert the job is already linked before _run() ever runs"
+        action: "assert"
+        target: "target_statement"
+        asserts:
+          mutasi_ai_job_ids:
+            type: "m2m"
+            check: "exact"
+            expected_records:
+              - "REC: job"
+
+  - name: "Job created without statement_id is not linked anywhere"
+    steps:
+      - step: "Create statement attachment"
+        action: "create"
+        model: "ir.attachment"
+        save_as: "attachment"
+        values:
+          name: "statement.pdf"
+          datas: "ZHVtbXkgcGRmIGNvbnRlbnQ="
+          type: "binary"
+      - step: "Create mutasi-ai backend"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.backend"
+        save_as: "backend"
+        values:
+          name: "Statement Link Test Backend"
+          code: "STMT-LINK-BACKEND-2"
+          base_url: "https://carik.example.com"
+          bearer_token: "test-token"
+      - step: "Create job without a target statement"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+      - step: "Assert the job is not linked to any statement"
+        action: "assert"
+        target: "job"
+        asserts:
+          statement_ids:
+            type: "m2m"
+            check: "count"
+            expected_count: 0

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -431,6 +431,7 @@ class TestImportMutasiAi(TransactionCase):
                 "statement_filename": "target_dedup.pdf",
                 "backend_id": self.backend.id,
                 "statement_id": target_statement.id,
+                "journal_id": self.bank_journal.id,
             }
         )
         self.assertIn(
@@ -516,6 +517,7 @@ class TestImportMutasiAi(TransactionCase):
                 "statement_filename": "target_success.pdf",
                 "backend_id": self.backend.id,
                 "statement_id": existing_statement.id,
+                "journal_id": self.bank_journal.id,
             }
         )
         with patch(

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -400,6 +400,146 @@ class TestImportMutasiAi(TransactionCase):
             "via mutasi_ai_job_ids",
         )
 
+    def test_run_dedup_with_target_statement_stays_linked(self):
+        """A fully-duplicate run against an explicit target stays linked.
+
+        Positive scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; ``odoo-yaml-test`` has no
+        mock/patch support). Regression coverage for backlog issue
+        #112: when every transaction in the file is a duplicate,
+        ``result["statement_ids"]`` comes back empty, and a
+        replace-all write would have severed the link ``create()``
+        already made between the job and its explicit
+        ``statement_id`` target — hiding the job from the very
+        statement the user is watching it on.
+        """
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        response = _sample_response(
+            unique_suffix="target-dedup", currency_code=self.company_currency
+        )
+        job1 = self._make_job(unique_suffix="target-dedup")
+        with patch(_CALL_SERVICE_PATH, return_value=response):
+            job1._run()
+        self.assertEqual(job1.state, "done")
+        target_statement = job1.statement_ids
+
+        attachment = self._make_attachment("target_dedup.pdf")
+        job2 = self.env[_JOB_MODEL].create(
+            {
+                "attachment_id": attachment.id,
+                "statement_filename": "target_dedup.pdf",
+                "backend_id": self.backend.id,
+                "statement_id": target_statement.id,
+            }
+        )
+        self.assertIn(
+            job2,
+            target_statement.mutasi_ai_job_ids,
+            "create() must link job2 to its target statement before "
+            "_run() ever executes",
+        )
+        with patch(_CALL_SERVICE_PATH, return_value=response):
+            job2._run()
+        self.assertEqual(job2.state, "already_imported")
+        self.assertFalse(
+            job2.statement_ids,
+            "a fully-duplicate run reports no statement in the result",
+        )
+        self.assertIn(
+            job2,
+            target_statement.mutasi_ai_job_ids,
+            "the link made at create() must survive a fully-duplicate "
+            "_run(), not be wiped by a replace-all write",
+        )
+
+    def test_run_failure_with_target_statement_stays_linked(self):
+        """A failed run leaves the job linked to its target statement.
+
+        Negative scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; ``odoo-yaml-test`` has no
+        mock/patch support). Regression coverage for backlog issue
+        #112: the ``except`` branch of ``_run()`` must not touch
+        ``statement_ids``, so a job that targeted an existing
+        statement and then failed is still visible on that statement.
+        """
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        existing_statement = self.env["account.bank.statement"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "date": "2026-01-31",
+            }
+        )
+        attachment = self._make_attachment("target_failure.pdf")
+        job = self.env[_JOB_MODEL].create(
+            {
+                "attachment_id": attachment.id,
+                "statement_filename": "target_failure.pdf",
+                "backend_id": self.backend.id,
+                "statement_id": existing_statement.id,
+            }
+        )
+        self.assertIn(job, existing_statement.mutasi_ai_job_ids)
+        with patch(_CALL_SERVICE_PATH, side_effect=UserError("boom")):
+            job._run()
+        self.assertEqual(job.state, "failed")
+        self.assertIn(
+            job,
+            existing_statement.mutasi_ai_job_ids,
+            "a failed _run() must not sever the link made at create()",
+        )
+
+    def test_run_success_with_target_statement_links_exactly_once(self):
+        """A successful run against a pre-linked target adds no duplicate.
+
+        Positive scenario — trigger P6 (L-15: an end-to-end job run
+        requires patching ``_call_service``; ``odoo-yaml-test`` has no
+        mock/patch support). Regression coverage for backlog issue
+        #112: ``create()`` already links the job to its explicit
+        ``statement_id`` target, so ``_run()``'s own link (``4``)
+        command for the same id must not create a duplicate relation
+        row.
+        """
+        if not self.bank_journal:
+            self.skipTest("No bank journal found in test environment")
+        existing_statement = self.env["account.bank.statement"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "date": "2026-01-31",
+            }
+        )
+        attachment = self._make_attachment("target_success.pdf")
+        job = self.env[_JOB_MODEL].create(
+            {
+                "attachment_id": attachment.id,
+                "statement_filename": "target_success.pdf",
+                "backend_id": self.backend.id,
+                "statement_id": existing_statement.id,
+            }
+        )
+        with patch(
+            _CALL_SERVICE_PATH,
+            return_value=_sample_response(
+                unique_suffix="target-success", currency_code=self.company_currency
+            ),
+        ):
+            job._run()
+        self.assertEqual(job.state, "done")
+        self.assertEqual(job.statement_ids, existing_statement)
+        self.env.cr.execute(
+            "SELECT COUNT(*) FROM "
+            "account_statement_import_mutasi_ai_job_statement_rel "
+            "WHERE job_id = %s AND statement_id = %s",
+            (job.id, existing_statement.id),
+        )
+        self.assertEqual(
+            self.env.cr.fetchone()[0],
+            1,
+            "the target statement must be linked exactly once, with "
+            "no duplicate relation row",
+        )
+
     def test_run_dedup_second_run_already_imported(self):
         """Re-importing an all-duplicate file is ``already_imported``.
 

--- a/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_import_mutasi_ai.py
@@ -443,9 +443,11 @@ class TestImportMutasiAi(TransactionCase):
         with patch(_CALL_SERVICE_PATH, return_value=response):
             job2._run()
         self.assertEqual(job2.state, "already_imported")
-        self.assertFalse(
+        self.assertEqual(
             job2.statement_ids,
-            "a fully-duplicate run reports no statement in the result",
+            target_statement,
+            "a fully-duplicate run's empty result must leave the link "
+            "made at create() untouched, not wipe it",
         )
         self.assertIn(
             job2,

--- a/ssi_account_statement_import_mutasi_ai/views/account_bank_statement_views.xml
+++ b/ssi_account_statement_import_mutasi_ai/views/account_bank_statement_views.xml
@@ -9,11 +9,7 @@
     <field name="inherit_id" ref="account.view_bank_statement_form" />
     <field name="arch" type="xml">
         <xpath expr="//notebook" position="inside">
-            <page
-                    name="mutasi_ai_jobs"
-                    string="Mutasi AI Import Jobs"
-                    attrs="{'invisible': [('mutasi_ai_job_ids', '=', [])]}"
-                >
+            <page name="mutasi_ai_jobs" string="Mutasi AI Import Jobs">
                 <field name="mutasi_ai_job_ids" readonly="1">
                     <tree
                             decoration-danger="state == 'failed'"


### PR DESCRIPTION
## Ringkasan

- Hapus `attrs` invisible pada page "Mutasi AI Import Jobs" di form bank statement
  sehingga page selalu tampil, termasuk saat statement belum punya job sama sekali.
- Tautkan job ke `statement_id` tujuannya sejak record job dibuat (`create()`), bukan
  hanya setelah `_run()` sukses, supaya job berstate `queued`/`processing`/`failed`
  tetap terlihat di statement tujuannya.
- Ubah penulisan `statement_ids` di `_run()` dari perintah ganti-seluruhnya
  (`(6, 0, [...])`) menjadi penambahan (`(4, id)`) per statement, supaya berkas yang
  seluruh transaksinya duplikat tidak menghapus tautan awal job ke statement
  tujuannya.

## Test plan

- [x] Skenario YAML: job dibuat dengan `statement_id` terisi langsung tertaut
- [x] Skenario YAML: job dibuat tanpa `statement_id` tidak tertaut ke statement mana pun
- [x] Python murni (P6/L-15, mock `_call_service`): job atas berkas duplikat penuh
      tetap tertaut ke statement tujuannya setelah `_run()`
- [x] Python murni (P6/L-15): job gagal (`UserError`) tetap tertaut ke statement
      tujuannya
- [x] Python murni (P6/L-15): job sukses tertaut tepat sekali, tanpa duplikat baris
      relasi (diverifikasi via query SQL ke tabel relasi)
- [ ] CI hijau

Closes #112