### PR TITLE
[UPD] ssi_account_statement_import_mutasi_ai: dedicated queue channel untuk job mutasi-ai

### DIFF
--- a/ssi_account_statement_import_mutasi_ai/__manifest__.py
+++ b/ssi_account_statement_import_mutasi_ai/__manifest__.py
@@ -25,6 +25,8 @@
         "security/ir_model_access/account_statement_import_mutasi_ai_backend.xml",
         "security/ir_model_access/account_statement_import_mutasi_ai_job.xml",
         "data/ir_sequence.xml",
+        "data/queue_job_channel_data.xml",
+        "data/queue_job_function_data.xml",
         "views/account_statement_import_mutasi_ai_backend_views.xml",
         "views/account_statement_import_mutasi_ai_job_views.xml",
         "views/account_statement_import_views.xml",

--- a/ssi_account_statement_import_mutasi_ai/data/queue_job_channel_data.xml
+++ b/ssi_account_statement_import_mutasi_ai/data/queue_job_channel_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!-- Dedicated queue_job channel for the mutasi-ai extraction job, so a
+         long-running extraction call (up to
+         CLAUDE_EXTRACTION_TIMEOUT_SECONDS, ~10 minutes) does not monopolize
+         the shared "root" channel used by every other queue_job in the
+         instance. See ssi-financial-accounting#122 for context. -->
+    <record id="channel_mutasi_ai" model="queue.job.channel">
+        <field name="name">mutasi_ai</field>
+        <field name="parent_id" ref="queue_job.channel_root" />
+    </record>
+</odoo>

--- a/ssi_account_statement_import_mutasi_ai/data/queue_job_function_data.xml
+++ b/ssi_account_statement_import_mutasi_ai/data/queue_job_function_data.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!-- Binds account.statement.import.mutasi.ai.job._run() to the
+         dedicated "root.mutasi_ai" channel above. retry_pattern is
+         intentionally left unset: _run() never re-raises (see its
+         docstring), so queue_job's retry mechanism is never triggered for
+         this job. -->
+    <record
+        id="job_function_account_statement_import_mutasi_ai_job_run"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="model_account_statement_import_mutasi_ai_job" />
+        <field name="method">_run</field>
+        <field name="channel_id" ref="channel_mutasi_ai" />
+    </record>
+</odoo>

--- a/ssi_account_statement_import_mutasi_ai/tests/__init__.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_account_statement_import_mutasi_ai_job_state
 from . import test_account_statement_import_mutasi_ai_job_retry_ok
 from . import test_account_statement_import_mutasi_ai_job_menu
 from . import test_account_statement_import_mutasi_ai_job_statement_link
+from . import test_account_statement_import_mutasi_ai_job_queue_channel

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_queue_channel.py
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_queue_channel.py
@@ -1,0 +1,17 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountStatementImportMutasiAiJobQueueChannel(YamlTransactionCase):
+    """Scenario tests for the dedicated ``root.mutasi_ai`` queue channel."""
+
+    def test_account_statement_import_mutasi_ai_job_queue_channel(self):
+        """Run the queue channel routing/data scenarios."""
+        self.run_yaml_scenario(
+            "test_account_statement_import_mutasi_ai_job_queue_channel.yaml"
+        )

--- a/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_queue_channel.yaml
+++ b/ssi_account_statement_import_mutasi_ai/tests/test_account_statement_import_mutasi_ai_job_queue_channel.yaml
@@ -1,0 +1,86 @@
+options:
+  auto_refresh: true
+
+setup:
+  steps:
+    - step: "Create statement attachment"
+      action: "create"
+      model: "ir.attachment"
+      save_as: "attachment"
+      values:
+        name: "statement.pdf"
+        datas: "ZHVtbXkgcGRmIGNvbnRlbnQ="
+        type: "binary"
+    - step: "Create mutasi-ai backend"
+      action: "create"
+      model: "account.statement.import.mutasi.ai.backend"
+      save_as: "backend"
+      values:
+        name: "Queue Channel Test Backend"
+        code: "EVAL: 'QCHANNEL-BACKEND-%d' % registry['attachment'].id"
+        base_url: "https://carik.example.com"
+        bearer_token: "test-token"
+        timeout_seconds: 600
+
+scenarios:
+  - name: "action_enqueue routes the job to the root.mutasi_ai channel"
+    steps:
+      - step: "Create job"
+        action: "create"
+        model: "account.statement.import.mutasi.ai.job"
+        save_as: "job"
+        values:
+          attachment_id: "REC: attachment.id"
+          backend_id: "REC: backend.id"
+      - step: "Enqueue the job, creating a real paired queue.job"
+        action: "call"
+        target: "job"
+        method: "action_enqueue"
+      - step: "Assert the paired queue.job runs on root.mutasi_ai"
+        action: "assert"
+        target: "job"
+        asserts:
+          queue_job_id.channel:
+            type: "value"
+            expected: "root.mutasi_ai"
+
+  - name: "channel_mutasi_ai is a child of root named mutasi_ai"
+    steps:
+      - step: "Look up the channel_mutasi_ai record"
+        action: "ref"
+        xml_id: "ssi_account_statement_import_mutasi_ai.channel_mutasi_ai"
+        save_as: "channel"
+      - step: "Assert channel name, parent and complete name"
+        action: "assert"
+        target: "channel"
+        asserts:
+          name:
+            type: "value"
+            expected: "mutasi_ai"
+          parent_id.name:
+            type: "value"
+            expected: "root"
+          complete_name:
+            type: "value"
+            expected: "root.mutasi_ai"
+
+  - name:
+      "job_function binds account.statement.import.mutasi.ai.job._run to the channel"
+    steps:
+      - step: "Look up the job_function record"
+        action: "ref"
+        xml_id: "ssi_account_statement_import_mutasi_ai.job_function_account_statement_import_mutasi_ai_job_run"
+        save_as: "job_function"
+      - step: "Assert model, method and channel of the job function"
+        action: "assert"
+        target: "job_function"
+        asserts:
+          model_id.model:
+            type: "value"
+            expected: "account.statement.import.mutasi.ai.job"
+          method:
+            type: "value"
+            expected: "_run"
+          channel:
+            type: "value"
+            expected: "root.mutasi_ai"


### PR DESCRIPTION
## Ringkasan

Menambah channel queue_job dedicated `root.mutasi_ai` untuk job async
`account.statement.import.mutasi.ai.job._run()`, yang bisa berjalan sampai
`CLAUDE_EXTRACTION_TIMEOUT_SECONDS` (~10 menit). Tanpa channel terpisah, job
ini diproses di channel `root` yang dipakai bersama seluruh job `queue_job`
lain di instance manapun modul ini terpasang.

Perubahan (data-only, tanpa mengubah `_enqueue()`/`with_delay()`):

* `data/queue_job_channel_data.xml` — record `queue.job.channel`
  `channel_mutasi_ai` (`name = "mutasi_ai"`, `parent_id` =
  `queue_job.channel_root`) → `complete_name == "root.mutasi_ai"`.
* `data/queue_job_function_data.xml` — record `queue.job.function`
  `job_function_account_statement_import_mutasi_ai_job_run` yang mengikat
  `account.statement.import.mutasi.ai.job._run` ke channel di atas.
  `retry_pattern` sengaja tidak diset karena `_run()` tidak pernah re-raise.
* `__manifest__.py` — daftarkan kedua berkas data baru.
* `tests/test_account_statement_import_mutasi_ai_job_queue_channel.{py,yaml}` —
  skenario uji perilaku (`action_enqueue` → `queue_job_id.channel ==
  "root.mutasi_ai"`) plus data channel & job function.

Catatan skala (di luar lingkup PR ini): channel baru ini baru berguna bila
kapasitas `root` di jobrunner dinaikkan (`root:<N>` dengan `N > 1`) di level
deployment — dicatat terpisah, bukan bagian dari perubahan modul ini.

Closes #122

## Test plan

- [x] Unit test baru menguji routing channel (perilaku) + record channel &
      job function (data), dijalankan oleh CI.