### PR TITLE
[UPD] ssi_financial_accounting: IK dan tour Bank Statement + Cash Register

### DIFF
--- a/ssi_financial_accounting/.ik-entry-point
+++ b/ssi_financial_accounting/.ik-entry-point
@@ -1,0 +1,2 @@
+account.bank.statement:bank_statement -- menu Bank Statements + grup bank_statement_*; alur rekonsiliasi bank
+account.bank.statement:cash_register -- menu Cash Registers + grup cash_register_*; alur buka/tutup kas

--- a/ssi_financial_accounting/README.rst
+++ b/ssi_financial_accounting/README.rst
@@ -7,6 +7,36 @@ Financial Accounting
 ====================
 
 
+Work Instruction
+================
+
+Bank Statement
+--------------
+
+* `Create Bank Statement <docs/account_bank_statement__bank_statement/01-create.html>`_
+* `Edit Bank Statement <docs/account_bank_statement__bank_statement/02-edit.html>`_
+* `Delete Bank Statement <docs/account_bank_statement__bank_statement/03-delete.html>`_
+* `Post Bank Statement <docs/account_bank_statement__bank_statement/04-post.html>`_
+* `Validate Bank Statement <docs/account_bank_statement__bank_statement/05-validate.html>`_
+* `Reset to New — Bank Statement <docs/account_bank_statement__bank_statement/06-reset-to-new.html>`_
+* `Reset to Processing — Bank Statement <docs/account_bank_statement__bank_statement/07-reset-to-processing.html>`_
+* `Print Bank Statement <docs/account_bank_statement__bank_statement/08-print.html>`_
+
+Cash Register
+-------------
+
+* `Create Cash Register <docs/account_bank_statement__cash_register/01-create.html>`_
+* `Edit Cash Register <docs/account_bank_statement__cash_register/02-edit.html>`_
+* `Delete Cash Register <docs/account_bank_statement__cash_register/03-delete.html>`_
+* `Post Cash Register <docs/account_bank_statement__cash_register/04-post.html>`_
+* `Validate Cash Register <docs/account_bank_statement__cash_register/05-validate.html>`_
+* `Reset to New — Cash Register <docs/account_bank_statement__cash_register/06-reset-to-new.html>`_
+* `Reset to Processing — Cash Register <docs/account_bank_statement__cash_register/07-reset-to-processing.html>`_
+* `Print Cash Register <docs/account_bank_statement__cash_register/08-print.html>`_
+* `Take Money In/Out — Cash Register <docs/account_bank_statement__cash_register/09-take-money-in-out.html>`_
+* `Count — Cash Register <docs/account_bank_statement__cash_register/10-count.html>`_
+
+
 Installation
 ============
 

--- a/ssi_financial_accounting/__manifest__.py
+++ b/ssi_financial_accounting/__manifest__.py
@@ -28,6 +28,7 @@
         "account_move_force_removal",
         "ssi_account_create_liquidity_journal",
         "account_mass_reconcile",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -78,6 +79,7 @@
         "report/templates/general_ledger.xml",
         "views/mass_reconcile_views.xml",
         "menu.xml",
+        "views/assets.xml",
     ],
     "demo": [],
 }

--- a/ssi_financial_accounting/docs/account_bank_statement__bank_statement/01-create.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__bank_statement/01-create.md
@@ -1,0 +1,40 @@
+# Create Bank Statement
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Bank Statements\
+> **Actor:** user in group \_Bank Statement — User*\
+> **State:** `—` → `open`\
+> **Inline Actions:** `action_reload_policy_template` (Reload Template Policy)
+
+## Pre-Condition
+
+- **Data:** An `account.journal` of type **Bank** exists.
+- **Access:** User is in group _Bank Statement — User_
+  (`ssi_financial_accounting.bank_statement_user_group`).
+- **Access:** User has full Accounting access (group _Show Full Accounting Features_,
+  `account.group_account_user`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Bank Statements** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Journal**: select the Bank journal this statement belongs to. Only journals of
+     type **Bank** are shown.
+   - **Date**: defaults to today. Change if needed.
+   - **Starting Balance**: defaults from the ending balance of the previous statement of
+     the same journal. Change if needed.
+   - **Ending Balance**: enter the real ending balance shown on the bank's statement.
+4. _(Optional, System group only)_ On the **Policies** tab, click **Reload Template
+   Policy** to re-evaluate which `policy.template` applies to this document. A matching
+   template is already assigned automatically when the record is created; use this
+   button only if something that affects the evaluation (e.g. the configured templates)
+   changed afterward. Skipping this step leaves the automatically assigned template
+   unchanged.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **New** status.
+- The document **Number** stays **/** until the statement is posted.

--- a/ssi_financial_accounting/docs/account_bank_statement__bank_statement/02-edit.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__bank_statement/02-edit.md
@@ -1,0 +1,30 @@
+# Edit Bank Statement
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Bank Statements\
+> **Actor:** user in group \_Bank Statement — User*\
+> **Requires:** `01-create`\
+> **Inline Actions:** `action_reload_policy_template` (Reload Template Policy)
+
+## Pre-Condition
+
+- **Record:** Status is **New**.
+- **Access:** User is in group _Bank Statement — User_
+  (`ssi_financial_accounting.bank_statement_user_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Bank Statements** menu.
+2. Find and open the record to edit.
+3. Change the required fields — **Journal**, **Date**, **Starting Balance**, **Ending
+   Balance**, or the **Transactions** lines.
+4. _(Optional, System group only)_ On the **Policies** tab, click **Reload Template
+   Policy** to re-evaluate which `policy.template` applies to this document — for
+   example after changing the **Journal**. Skipping this step leaves the currently
+   assigned template unchanged.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_financial_accounting/docs/account_bank_statement__bank_statement/03-delete.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__bank_statement/03-delete.md
@@ -1,0 +1,26 @@
+# Delete Bank Statement
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Bank Statements\
+> **Actor:** user in group \_Bank Statement — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **New**. A statement that has been posted (or later) must first
+  be reset to **New** — see `06-reset-to-new` — before it can be deleted.
+- **Access:** User is in group _Bank Statement — User_
+  (`ssi_financial_accounting.bank_statement_user_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Bank Statements** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records, and their transaction lines, are permanently removed from the
+  system.

--- a/ssi_financial_accounting/docs/account_bank_statement__bank_statement/04-post.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__bank_statement/04-post.md
@@ -1,0 +1,30 @@
+# Post Bank Statement
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Bank Statements\
+> **Actor:** user in group \_Bank Statement — User*\
+> **State:** `open` → `posted`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **New**.
+- **Config:** An active `policy.template` for this model grants `post_ok` for state
+  `open` to the actor's group (`policy_template_bank_statement_bank`).
+- **Access:** User is in group _Bank Statement — User_
+  (`ssi_financial_accounting.bank_statement_user_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Bank Statements** menu.
+2. Open the record to post.
+3. Click the **Post** button.
+
+## Post-Condition
+
+- Status changes to **Processing**.
+- The statement's document **Number** is generated (no longer **/**).
+- The related journal entries of the transaction lines are posted.
+- If the statement has no transaction lines, it is automatically validated as well —
+  status goes straight to **Validated** (see `05-validate`).

--- a/ssi_financial_accounting/docs/account_bank_statement__bank_statement/05-validate.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__bank_statement/05-validate.md
@@ -1,0 +1,30 @@
+# Validate Bank Statement
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Bank Statements\
+> **Actor:** user in group \_Bank Statement — Validator*\
+> **State:** `posted` → `confirm`\
+> **Requires:** `04-post`
+
+## Pre-Condition
+
+- **Record:** Status is **Processing**.
+- **Record:** At least one transaction line exists, and every line is reconciled.
+- **Config:** An active `policy.template` for this model grants `validate_ok` for state
+  `posted` to the actor's group, and requires all lines to be reconciled
+  (`policy_template_bank_statement_bank`).
+- **Access:** User is in group _Bank Statement — Validator_
+  (`ssi_financial_accounting.bank_statement_validator_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Bank Statements** menu.
+2. Open the record to validate.
+3. Click the **Validate** button.
+
+## Post-Condition
+
+- Status changes to **Validated**.
+- The **Closed On** date is set to the current date and time.
+- For a Bank journal, a PDF copy of the statement is attached to the record.

--- a/ssi_financial_accounting/docs/account_bank_statement__bank_statement/06-reset-to-new.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__bank_statement/06-reset-to-new.md
@@ -1,0 +1,28 @@
+# Reset to New — Bank Statement
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Bank Statements\
+> **Actor:** user in group \_Bank Statement — Validator*\
+> **State:** `posted` → `open`\
+> **Requires:** `04-post`
+
+## Pre-Condition
+
+- **Record:** Status is **Processing**.
+- **Config:** An active `policy.template` for this model grants `reopen_ok` for state
+  `posted` to the actor's group (`policy_template_bank_statement_bank`).
+- **Access:** User is in group _Bank Statement — Validator_
+  (`ssi_financial_accounting.bank_statement_validator_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Bank Statements** menu.
+2. Open the record to reset.
+3. Click the **Reset to New** button.
+
+## Post-Condition
+
+- Status changes back to **New**.
+- The related journal entries of the transaction lines are reset to draft.
+- The reconciliation of the transaction lines is undone.

--- a/ssi_financial_accounting/docs/account_bank_statement__bank_statement/07-reset-to-processing.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__bank_statement/07-reset-to-processing.md
@@ -1,0 +1,27 @@
+# Reset to Processing — Bank Statement
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Bank Statements\
+> **Actor:** user in group \_Bank Statement — User*\
+> **State:** `confirm` → `posted`\
+> **Requires:** `05-validate`
+
+## Pre-Condition
+
+- **Record:** Status is **Validated**.
+- **Config:** An active `policy.template` for this model grants `reprocess_ok` for state
+  `confirm` to the actor's group (`policy_template_bank_statement_bank`).
+- **Access:** User is in group _Bank Statement — User_
+  (`ssi_financial_accounting.bank_statement_user_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Bank Statements** menu.
+2. Open the record to reset.
+3. Click the **Reset to Processing** button.
+
+## Post-Condition
+
+- Status changes back to **Processing**.
+- The **Closed On** date is cleared.

--- a/ssi_financial_accounting/docs/account_bank_statement__bank_statement/08-print.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__bank_statement/08-print.md
@@ -1,0 +1,28 @@
+# Print Bank Statement
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Bank Statements\
+> **Actor:** user in group \_Bank Statement — Viewer*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record exists, in any status.
+- **Data:** At least one `ir.actions.report` is registered for `account.bank.statement`
+  (the **Statement** report from Odoo core is registered by default).
+- **Access:** User is in group _Bank Statement — Viewer_
+  (`ssi_financial_accounting.bank_statement_viewer_group`), or higher.
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Bank Statements** menu.
+2. Open the record to print.
+3. Click the **Print** button.
+4. In the **Select Report To Print** wizard, select a **Type** (if more than one is
+   available) and the **Report Template**.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and downloaded as a PDF.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/01-create.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/01-create.md
@@ -1,0 +1,41 @@
+# Create Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — User*\
+> **State:** `—` → `open`\
+> **Inline Actions:** `action_reload_policy_template` (Reload Template Policy)
+
+## Pre-Condition
+
+- **Data:** An `account.journal` of type **Cash** exists.
+- **Access:** User is in group _Cash Register — User_
+  (`ssi_financial_accounting.cash_register_user_group`).
+- **Access:** User has full Accounting access (group _Show Full Accounting Features_,
+  `account.group_account_user`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Journal**: select the Cash journal this register belongs to. Only journals of
+     type **Cash** are shown.
+   - **Date**: defaults to today. Change if needed.
+   - **Starting Balance**: defaults from the ending balance of the previous statement of
+     the same journal. Change if needed — see also `10-count` for calculating it from a
+     physical cash count.
+   - **Ending Balance**: enter the counted ending balance — see also `10-count`.
+4. _(Optional, System group only)_ On the **Policies** tab, click **Reload Template
+   Policy** to re-evaluate which `policy.template` applies to this document. A matching
+   template is already assigned automatically when the record is created; use this
+   button only if something that affects the evaluation (e.g. the configured templates)
+   changed afterward. Skipping this step leaves the automatically assigned template
+   unchanged.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **New** status.
+- The document **Number** stays **/** until the register is posted.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/02-edit.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/02-edit.md
@@ -1,0 +1,30 @@
+# Edit Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — User*\
+> **Requires:** `01-create`\
+> **Inline Actions:** `action_reload_policy_template` (Reload Template Policy)
+
+## Pre-Condition
+
+- **Record:** Status is **New**.
+- **Access:** User is in group _Cash Register — User_
+  (`ssi_financial_accounting.cash_register_user_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Find and open the record to edit.
+3. Change the required fields — **Journal**, **Date**, **Starting Balance**, **Ending
+   Balance**, or the **Transactions** lines.
+4. _(Optional, System group only)_ On the **Policies** tab, click **Reload Template
+   Policy** to re-evaluate which `policy.template` applies to this document — for
+   example after changing the **Journal**. Skipping this step leaves the currently
+   assigned template unchanged.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/03-delete.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/03-delete.md
@@ -1,0 +1,26 @@
+# Delete Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **New**. A register that has been posted (or later) must first
+  be reset to **New** — see `06-reset-to-new` — before it can be deleted.
+- **Access:** User is in group _Cash Register — User_
+  (`ssi_financial_accounting.cash_register_user_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records, and their transaction lines, are permanently removed from the
+  system.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/04-post.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/04-post.md
@@ -1,0 +1,30 @@
+# Post Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — User*\
+> **State:** `open` → `posted`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **New**.
+- **Config:** An active `policy.template` for this model grants `post_ok` for state
+  `open` to the actor's group (`policy_template_bank_statement_cash`).
+- **Access:** User is in group _Cash Register — User_
+  (`ssi_financial_accounting.cash_register_user_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Open the record to post.
+3. Click the **Post** button.
+
+## Post-Condition
+
+- Status changes to **Processing**.
+- The register's document **Number** is generated (no longer **/**).
+- The related journal entries of the transaction lines are posted.
+- If the register has no transaction lines, it is automatically validated as well —
+  status goes straight to **Validated** (see `05-validate`).

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/05-validate.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/05-validate.md
@@ -1,0 +1,32 @@
+# Validate Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — Validator*\
+> **State:** `posted` → `confirm`\
+> **Requires:** `04-post`
+
+## Pre-Condition
+
+- **Record:** Status is **Processing**.
+- **Record:** At least one transaction line exists, and every line is reconciled.
+- **Record:** The computed ending balance matches the **Ending Balance** entered on the
+  register. If it does not match, a **difference confirmation** wizard opens instead of
+  validating directly.
+- **Config:** An active `policy.template` for this model grants `validate_ok` for state
+  `posted` to the actor's group, and requires all lines to be reconciled
+  (`policy_template_bank_statement_cash`).
+- **Access:** User is in group _Cash Register — Validator_
+  (`ssi_financial_accounting.cash_register_validator_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Open the record to validate.
+3. Click the **Validate** button.
+
+## Post-Condition
+
+- Status changes to **Validated**.
+- The **Closed On** date is set to the current date and time.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/06-reset-to-new.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/06-reset-to-new.md
@@ -1,0 +1,28 @@
+# Reset to New — Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — Validator*\
+> **State:** `posted` → `open`\
+> **Requires:** `04-post`
+
+## Pre-Condition
+
+- **Record:** Status is **Processing**.
+- **Config:** An active `policy.template` for this model grants `reopen_ok` for state
+  `posted` to the actor's group (`policy_template_bank_statement_cash`).
+- **Access:** User is in group _Cash Register — Validator_
+  (`ssi_financial_accounting.cash_register_validator_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Open the record to reset.
+3. Click the **Reset to New** button.
+
+## Post-Condition
+
+- Status changes back to **New**.
+- The related journal entries of the transaction lines are reset to draft.
+- The reconciliation of the transaction lines is undone.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/07-reset-to-processing.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/07-reset-to-processing.md
@@ -1,0 +1,27 @@
+# Reset to Processing — Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — User*\
+> **State:** `confirm` → `posted`\
+> **Requires:** `05-validate`
+
+## Pre-Condition
+
+- **Record:** Status is **Validated**.
+- **Config:** An active `policy.template` for this model grants `reprocess_ok` for state
+  `confirm` to the actor's group (`policy_template_bank_statement_cash`).
+- **Access:** User is in group _Cash Register — User_
+  (`ssi_financial_accounting.cash_register_user_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Open the record to reset.
+3. Click the **Reset to Processing** button.
+
+## Post-Condition
+
+- Status changes back to **Processing**.
+- The **Closed On** date is cleared.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/08-print.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/08-print.md
@@ -1,0 +1,28 @@
+# Print Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — Viewer*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record exists, in any status.
+- **Data:** At least one `ir.actions.report` is registered for `account.bank.statement`
+  (the **Statement** report from Odoo core is registered by default).
+- **Access:** User is in group _Cash Register — Viewer_
+  (`ssi_financial_accounting.cash_register_viewer_group`), or higher.
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Open the record to print.
+3. Click the **Print** button.
+4. In the **Select Report To Print** wizard, select a **Type** (if more than one is
+   available) and the **Report Template**.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and downloaded as a PDF.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/09-take-money-in-out.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/09-take-money-in-out.md
@@ -1,0 +1,32 @@
+# Take Money In/Out — Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **New** or **Processing** (not **Validated** — attempting this
+  on a Validated register raises an error).
+- **Data:** The register's company has an **Internal Transfer Account** configured
+  (`res.company.transfer_account_id`).
+- **Config:** An active `policy.template` for this model grants `cash_box_ok` to the
+  actor's group for a Cash journal (`policy_template_bank_statement_cash`).
+- **Access:** User is in group _Cash Register — User_
+  (`ssi_financial_accounting.cash_register_user_group`).
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Open the register.
+3. Click the **Take Money In/Out** button.
+4. In the wizard that appears, fill in:
+   - **Reason**: why money is being put into or taken from the cash box.
+   - **Amount**: a positive amount adds money in, a negative amount takes money out.
+5. Click **Take Money In/Out** to confirm, or **Cancel** to discard.
+
+## Post-Condition
+
+- A new transaction line is added to the register with the entered amount and reason.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/10-count.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/10-count.md
@@ -1,0 +1,29 @@
+# Count — Cash Register
+
+> **Module:** ssi*financial_accounting\
+> **Model:** `account.bank.statement`\
+> **Menu:** Financial Accounting > Bank & Cash > Cash Registers\
+> **Actor:** user in group \_Cash Register — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **New**.
+
+## Flow
+
+1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
+2. Open the register.
+3. Next to **Starting Balance** or **Ending Balance**, click **→ Count**.
+4. In the cash-count wizard, for each coin/note denomination counted, click **Add a
+   line** and fill in:
+   - **Coin/Bill Value**: the denomination's value (e.g. `50000`, `1000`, `500`).
+   - **#Coins/Bills**: how many pieces of that denomination were counted. The
+     **Subtotal** per line and the **Total** at the bottom are calculated automatically.
+5. Click **Confirm** to apply the counted total to the balance, or **Cancel** to
+   discard.
+
+## Post-Condition
+
+- The **Starting Balance** (or **Ending Balance**, depending on which **→ Count** link
+  was used) is set to the counted **Total**.

--- a/ssi_financial_accounting/docs/account_bank_statement__cash_register/10-count.md
+++ b/ssi_financial_accounting/docs/account_bank_statement__cash_register/10-count.md
@@ -14,13 +14,14 @@
 
 1. Open the **Financial Accounting > Bank & Cash > Cash Registers** menu.
 2. Open the register.
-3. Next to **Starting Balance** or **Ending Balance**, click **→ Count**.
-4. In the cash-count wizard, for each coin/note denomination counted, click **Add a
+3. Click **Edit**. The **→ Count** link is only shown while the form is in edit mode.
+4. Next to **Starting Balance** or **Ending Balance**, click **→ Count**.
+5. In the cash-count wizard, for each coin/note denomination counted, click **Add a
    line** and fill in:
    - **Coin/Bill Value**: the denomination's value (e.g. `50000`, `1000`, `500`).
    - **#Coins/Bills**: how many pieces of that denomination were counted. The
      **Subtotal** per line and the **Total** at the bottom are calculated automatically.
-5. Click **Confirm** to apply the counted total to the balance, or **Cancel** to
+6. Click **Confirm** to apply the counted total to the balance, or **Cancel** to
    discard.
 
 ## Post-Condition

--- a/ssi_financial_accounting/static/tests/tours/account_bank_statement__bank_statement_tour.js
+++ b/ssi_financial_accounting/static/tests/tours/account_bank_statement__bank_statement_tour.js
@@ -1,0 +1,317 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define(
+    "ssi_financial_accounting.account_bank_statement__bank_statement_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // Shared navigation: Financial Accounting > Bank & Cash > Bank
+        // Statements. "Bank & Cash" (level 2) has children so it renders as
+        // a dropdown-toggle; "Bank Statements" (level 3) is a leaf. The
+        // landing menu of the app is "Invoices" (Account Receivable), so no
+        // substring collision guard is needed here (patterns.md §A).
+        function openBankStatementsMenu() {
+            return [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Financial Accounting app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_financial_accounting.menu_root_financial_accounting"]',
+                },
+                {
+                    content: "Open the Bank & Cash menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_financial_accounting.menu_bank_cash"]',
+                },
+                {
+                    content: "Open the Bank Statements menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_financial_accounting.account_bank_statement_menu"]',
+                },
+                {
+                    content: "Bank Statements list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Bank Statements)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ];
+        }
+
+        // Open the fixture record identified by its Journal column value
+        // (the Journal column is shown in the tree, unlike the record's
+        // own "name", which is still "/" before the statement is posted).
+        function openRecordByJournal(journalName) {
+            return [
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(" + journalName + ") .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ];
+        }
+
+        // IK: docs/account_bank_statement__bank_statement/01-create.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_bank_statement_create",
+            {test: true, url: "/web"},
+            [].concat(openBankStatementsMenu(), [
+                // Flow 2 -- Click New.
+                {
+                    content: "Click New",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Flow 3 -- Journal (many2one rendered with
+                // widget="selection" -> <select>, gabungan tag+class,
+                // NOT a descendant "input"; field-writing-rules.md
+                // "Field selection" table).
+                {
+                    content: "Select the Journal",
+                    trigger: "select.o_field_widget[name='journal_id']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text Tour Bank Statement Create",
+                },
+                // Flow 3 -- Ending Balance (Monetary widget wraps the
+                // input, so " input" is required here).
+                {
+                    content: "Fill in the Ending Balance",
+                    trigger: ".o_field_widget[name='balance_end_real'] input",
+                    run: "text 100.0",
+                },
+
+                // Flow 4 (Inline Action, System group only) -- on the
+                // Policies tab, click Reload Template Policy. Optional
+                // per the IK text, but exercised here to prove the
+                // button actually works, following the precedent in
+                // ssi_customer_invoice_export's create tour.
+                {
+                    content: "Open the Policies tab",
+                    trigger: ".o_notebook .nav-link:contains(Policies)",
+                },
+                {
+                    content: "Click Reload Template Policy",
+                    trigger: "button[name='action_reload_policy_template']",
+                },
+                {
+                    content: "Reload Template Policy call has completed",
+                    trigger: "button[name='action_reload_policy_template']:enabled",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Flow 5 -- Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Post-Condition -- status is New.
+                {
+                    content: "Status is New",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ])
+        );
+
+        // IK: docs/account_bank_statement__bank_statement/04-post.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_bank_statement_post",
+            {test: true, url: "/web"},
+            [].concat(
+                openBankStatementsMenu(),
+                openRecordByJournal("Tour Bank Statement Post"),
+                [
+                    // Flow 3 -- Click Post.
+                    {
+                        content: "Click the Post button",
+                        trigger: ".o_statusbar_buttons button[name='button_post']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Post-Condition -- status is Processing.
+                    {
+                        content: "Status is Processing",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='posted'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__bank_statement/05-validate.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_bank_statement_validate",
+            {test: true, url: "/web"},
+            [].concat(
+                openBankStatementsMenu(),
+                openRecordByJournal("Tour Bank Statement Validate"),
+                [
+                    // Flow 3 -- Click Validate.
+                    {
+                        content: "Click the Validate button",
+                        trigger:
+                            ".o_statusbar_buttons button[name='button_validate_or_action']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Post-Condition -- status is Validated.
+                    {
+                        content: "Status is Validated",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__bank_statement/06-reset-to-new.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_bank_statement" +
+                "_reset_to_new",
+            {test: true, url: "/web"},
+            [].concat(
+                openBankStatementsMenu(),
+                openRecordByJournal("Tour Bank Statement Reset New"),
+                [
+                    // Flow 3 -- Click Reset to New.
+                    {
+                        content: "Click the Reset to New button",
+                        trigger: ".o_statusbar_buttons button[name='button_reopen']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Post-Condition -- status is New.
+                    {
+                        content: "Status is New",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__bank_statement/07-reset-to-processing.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_bank_statement" +
+                "_reset_to_processing",
+            {test: true, url: "/web"},
+            [].concat(
+                openBankStatementsMenu(),
+                openRecordByJournal("Tour Bank Statement Reset Processing"),
+                [
+                    // Flow 3 -- Click Reset to Processing.
+                    {
+                        content: "Click the Reset to Processing button",
+                        trigger: ".o_statusbar_buttons button[name='button_reprocess']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Post-Condition -- status is Processing.
+                    {
+                        content: "Status is Processing",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='posted'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__bank_statement/08-print.md
+        //
+        // Bounded per odoo-development-ui-test skill, patterns.md §Q: the
+        // Print wizard's own Print button returns a report action with no
+        // DOM "finished" signal (it triggers a PDF download) and is never
+        // clicked here -- the tour only proves the wizard opens with a
+        // report available, then discards it.
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_bank_statement_print",
+            {test: true, url: "/web"},
+            [].concat(
+                openBankStatementsMenu(),
+                openRecordByJournal("Tour Bank Statement Print"),
+                [
+                    // Flow 3 -- Click Print. The button name is a
+                    // numeric action id in the DOM (id="%(...)d"
+                    // template), never a stable [name=...] -- see
+                    // odoo-development-ui-test skill, patterns-dialogs-
+                    // and-wizards.md §H point 1.
+                    {
+                        content: "Click the Print button",
+                        trigger: ".o_statusbar_buttons button:contains(Print)",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Flow 4-5 stop here (see module comment above): the
+                    // wizard is shown to be usable, but the Print button
+                    // inside it is not clicked.
+                    {
+                        content: "The Select Report To Print wizard is displayed",
+                        trigger: ".o_form_view",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                    {
+                        content: "A report is available and Print is enabled",
+                        trigger: ".modal-footer button[name='action_print']:enabled",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                    {
+                        content: "Cancel the wizard",
+                        trigger: ".modal-footer button:contains(Cancel)",
+                    },
+                    {
+                        content: "Wizard is closed",
+                        trigger: "body:not(:has(.modal))",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+    }
+);

--- a/ssi_financial_accounting/static/tests/tours/account_bank_statement__bank_statement_tour.js
+++ b/ssi_financial_accounting/static/tests/tours/account_bank_statement__bank_statement_tour.js
@@ -114,9 +114,19 @@ odoo.define(
                     content: "Click Reload Template Policy",
                     trigger: "button[name='action_reload_policy_template']",
                 },
+                // Action_reload_policy_template is a type="object" button
+                // in the sheet, so _onButtonClicked saves the (still new)
+                // record with stayInEdit: true -- the form stays in edit
+                // mode, and the button itself is never touched by
+                // disableButtons (that only covers .o_statusbar_buttons /
+                // .oe_button_box, per form_renderer.js). The real "call has
+                // completed" signal is the toolbar Save button, which
+                // FormController._disableButtons *does* disable for the
+                // duration of the async save+action call and re-enables
+                // once it settles.
                 {
                     content: "Reload Template Policy call has completed",
-                    trigger: "button[name='action_reload_policy_template']:enabled",
+                    trigger: ".o_form_buttons_edit .o_form_button_save:not([disabled])",
                     run: function () {
                         // Assertion only.
                     },

--- a/ssi_financial_accounting/static/tests/tours/account_bank_statement__cash_register_tour.js
+++ b/ssi_financial_accounting/static/tests/tours/account_bank_statement__cash_register_tour.js
@@ -479,18 +479,27 @@ odoo.define(
                     },
 
                     // Flow 5 -- add a denomination line and fill it in.
-                    // coin_value (Float) and number (Integer) both extend
-                    // NumericField, which renders its root element as the
-                    // <input> itself in edit mode (see the Reason/Amount
-                    // comment above) -- NO " input" suffix, otherwise the
-                    // selector never matches and the step times out.
+                    // The effective widget is decided by tree column
+                    // markup, not the Python field type alone (account/
+                    // views/account_bank_statement_views.xml,
+                    // view_account_bnk_stmt_cashbox): coin_value carries
+                    // widget="monetary" there even though its Python type
+                    // is Float, so it renders as FieldMonetary -- root
+                    // <div class="o_input"> with the <input> appended
+                    // (FieldMonetary.init sets tagName = 'div' AFTER
+                    // calling super) -- the " input" suffix IS required,
+                    // same as balance_end_real/Amount above. number has no
+                    // widget override, so it stays plain Integer
+                    // (NumericField) -- root element is the <input> itself
+                    // in edit mode, NO " input" suffix.
                     {
                         content: "Add a cashbox line",
                         trigger: ".o_field_x2many .o_field_x2many_list_row_add a",
                     },
                     {
                         content: "Fill in the Coin/Bill Value",
-                        trigger: ".o_selected_row .o_field_widget[name='coin_value']",
+                        trigger:
+                            ".o_selected_row .o_field_widget[name='coin_value'] input",
                         run: "text 50000",
                     },
                     {

--- a/ssi_financial_accounting/static/tests/tours/account_bank_statement__cash_register_tour.js
+++ b/ssi_financial_accounting/static/tests/tours/account_bank_statement__cash_register_tour.js
@@ -349,38 +349,51 @@ odoo.define(
                             ".o_statusbar_buttons button:contains(Take Money In/Out)",
                         extra_trigger: ".o_form_view",
                     },
-                    // 14.0: JANGAN prefiks `.modal` -- web_tour/
-                    // tour_manager.js sudah mencari trigger DI DALAM modal
-                    // lewat $modal_displayed.find(...) begitu modal
-                    // terbuka (patterns-dialogs-and-wizards.md §H);
-                    // ".modal ..." menuntut modal bersarang yang tak ada
-                    // dan timeout, tergerbangi validate-tour.sh §4.
+                    // The wizard is a modal -- the trigger below must only
+                    // match once the modal is actually open, not the
+                    // background form that is already ".o_form_view"
+                    // before the button click resolves (odoo-development-
+                    // ui-test skill, patterns.md litmus test). This step is
+                    // the one that WAITS FOR the modal to appear, so
+                    // `in_modal: false` is required: with the 14.0 default
+                    // (`in_modal: true`), tour_manager.js searches
+                    // $modal_displayed.find(trigger) -- but $modal_displayed
+                    // IS ".modal", and .find() only sees descendants, so a
+                    // bare ".modal-title" trigger would never be reachable
+                    // before the modal exists to search inside of
+                    // (patterns-dialogs-and-wizards.md §H). validate-tour.sh
+                    // §4 excludes ".modal-title" selectors from the
+                    // no-".modal"-prefix gate for exactly this reason.
                     {
                         content: "The Take Money In/Out wizard is displayed",
-                        trigger: ".o_form_view",
+                        trigger: ".modal-title:contains(Take Money In/Out)",
+                        in_modal: false,
                         run: function () {
                             // Assertion only.
                         },
                     },
 
                     // Flow 4 -- fill Reason and Amount. Char (FieldChar)
-                    // and Float (NumericField) both use tagName: 'span' as
-                    // their root element (web/static/src/js/fields/
-                    // basic_fields.js), so .o_field_widget[name=...] is
-                    // the <span> wrapper, NOT the <input> -- the " input"
-                    // suffix is required, same as balance_end_real in the
-                    // create tour. "text ..." run on the <span> wrapper
-                    // falls back to $element.focusIn(), which is only
-                    // defined by web_editor's rte.js and is absent from
-                    // this bundle, raising a TypeError.
+                    // and Float (NumericField) both render their root
+                    // element as the <input> itself in edit mode
+                    // (InputField.init sets `this.tagName = 'input'`;
+                    // NumericField's own `tagName: 'span'` prototype value
+                    // is shadowed by that instance assignment --
+                    // web/static/src/js/fields/basic_fields.js). So
+                    // .o_field_widget[name=...] IS the <input> here -- NO
+                    // " input" suffix. Only Monetary (balance_end_real)
+                    // wraps the input in a <div>, because FieldMonetary's
+                    // own init overrides tagName to 'div' AFTER calling
+                    // super. A trailing " input" here would look for a
+                    // nested <input> that does not exist and time out.
                     {
                         content: "Fill in the Reason",
-                        trigger: ".o_field_widget[name='name'] input",
+                        trigger: ".o_field_widget[name='name']",
                         run: "text Tour Cash In",
                     },
                     {
                         content: "Fill in the Amount",
-                        trigger: ".o_field_widget[name='amount'] input",
+                        trigger: ".o_field_widget[name='amount']",
                         run: "text 50",
                     },
 
@@ -448,9 +461,18 @@ odoo.define(
                             "button[name='open_cashbox_id']",
                         extra_trigger: ".o_form_view",
                     },
+                    // Same litmus test as the Take Money In/Out wizard
+                    // above: ".o_form_view" alone also matches the
+                    // background form (already rendered before this modal
+                    // opens), so it is not a valid gate for "the modal
+                    // appeared". `in_modal: false` for the same reason as
+                    // above -- this step waits FOR the modal to exist, so
+                    // the 14.0 default in-modal scoping
+                    // ($modal_displayed.find(...)) cannot be used yet.
                     {
                         content: "The cash-count wizard is displayed",
-                        trigger: ".o_form_view",
+                        trigger: ".modal-title:contains(Cash Control)",
+                        in_modal: false,
                         run: function () {
                             // Assertion only.
                         },
@@ -458,24 +480,22 @@ odoo.define(
 
                     // Flow 5 -- add a denomination line and fill it in.
                     // coin_value (Float) and number (Integer) both extend
-                    // NumericField, tagName: 'span' (web/static/src/js/
-                    // fields/basic_fields.js), same as Amount in the Take
-                    // Money In/Out wizard -- the " input" suffix is
-                    // required, otherwise "text ..." falls back to
-                    // $element.focusIn(), which raises a TypeError.
+                    // NumericField, which renders its root element as the
+                    // <input> itself in edit mode (see the Reason/Amount
+                    // comment above) -- NO " input" suffix, otherwise the
+                    // selector never matches and the step times out.
                     {
                         content: "Add a cashbox line",
                         trigger: ".o_field_x2many .o_field_x2many_list_row_add a",
                     },
                     {
                         content: "Fill in the Coin/Bill Value",
-                        trigger:
-                            ".o_selected_row .o_field_widget[name='coin_value'] input",
+                        trigger: ".o_selected_row .o_field_widget[name='coin_value']",
                         run: "text 50000",
                     },
                     {
                         content: "Fill in the #Coins/Bills",
-                        trigger: ".o_selected_row .o_field_widget[name='number'] input",
+                        trigger: ".o_selected_row .o_field_widget[name='number']",
                         run: "text 2",
                     },
 

--- a/ssi_financial_accounting/static/tests/tours/account_bank_statement__cash_register_tour.js
+++ b/ssi_financial_accounting/static/tests/tours/account_bank_statement__cash_register_tour.js
@@ -116,9 +116,19 @@ odoo.define(
                     content: "Click Reload Template Policy",
                     trigger: "button[name='action_reload_policy_template']",
                 },
+                // Action_reload_policy_template is a type="object" button
+                // in the sheet, so _onButtonClicked saves the (still new)
+                // record with stayInEdit: true -- the form stays in edit
+                // mode, and the button itself is never touched by
+                // disableButtons (that only covers .o_statusbar_buttons /
+                // .oe_button_box, per form_renderer.js). The real "call has
+                // completed" signal is the toolbar Save button, which
+                // FormController._disableButtons *does* disable for the
+                // duration of the async save+action call and re-enables
+                // once it settles.
                 {
                     content: "Reload Template Policy call has completed",
-                    trigger: "button[name='action_reload_policy_template']:enabled",
+                    trigger: ".o_form_buttons_edit .o_form_button_save:not([disabled])",
                     run: function () {
                         // Assertion only.
                     },
@@ -339,6 +349,12 @@ odoo.define(
                             ".o_statusbar_buttons button:contains(Take Money In/Out)",
                         extra_trigger: ".o_form_view",
                     },
+                    // 14.0: JANGAN prefiks `.modal` -- web_tour/
+                    // tour_manager.js sudah mencari trigger DI DALAM modal
+                    // lewat $modal_displayed.find(...) begitu modal
+                    // terbuka (patterns-dialogs-and-wizards.md §H);
+                    // ".modal ..." menuntut modal bersarang yang tak ada
+                    // dan timeout, tergerbangi validate-tour.sh §4.
                     {
                         content: "The Take Money In/Out wizard is displayed",
                         trigger: ".o_form_view",
@@ -347,16 +363,24 @@ odoo.define(
                         },
                     },
 
-                    // Flow 4 -- fill Reason and Amount. Char/Float root
-                    // elements are the <input> itself (no " input" suffix).
+                    // Flow 4 -- fill Reason and Amount. Char (FieldChar)
+                    // and Float (NumericField) both use tagName: 'span' as
+                    // their root element (web/static/src/js/fields/
+                    // basic_fields.js), so .o_field_widget[name=...] is
+                    // the <span> wrapper, NOT the <input> -- the " input"
+                    // suffix is required, same as balance_end_real in the
+                    // create tour. "text ..." run on the <span> wrapper
+                    // falls back to $element.focusIn(), which is only
+                    // defined by web_editor's rte.js and is absent from
+                    // this bundle, raising a TypeError.
                     {
                         content: "Fill in the Reason",
-                        trigger: ".o_field_widget[name='name']",
+                        trigger: ".o_field_widget[name='name'] input",
                         run: "text Tour Cash In",
                     },
                     {
                         content: "Fill in the Amount",
-                        trigger: ".o_field_widget[name='amount']",
+                        trigger: ".o_field_widget[name='amount'] input",
                         run: "text 50",
                     },
 
@@ -394,7 +418,24 @@ odoo.define(
                 openCashRegistersMenu(),
                 openRecordByJournal("Tour Cash Register Count"),
                 [
-                    // Flow 3 -- click the "-> Count" link next to Starting
+                    // Flow 3 -- Click Edit. The "-> Count" button carries
+                    // class="oe_edit_only" (account/views/
+                    // account_bank_statement_views.xml), so it is hidden
+                    // while the form is in readonly mode.
+                    {
+                        content: "Click Edit",
+                        trigger: ".o_form_button_edit",
+                        extra_trigger: ".o_form_view.o_form_readonly",
+                    },
+                    {
+                        content: "Form is open in edit mode",
+                        trigger: ".o_form_view.o_form_editable",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+
+                    // Flow 4 -- click the "-> Count" link next to Starting
                     // Balance. Both Count buttons share the same
                     // name="open_cashbox_id"; disambiguate structurally by
                     // the field it sits next to (view XML: both are
@@ -415,23 +456,30 @@ odoo.define(
                         },
                     },
 
-                    // Flow 4 -- add a denomination line and fill it in.
+                    // Flow 5 -- add a denomination line and fill it in.
+                    // coin_value (Float) and number (Integer) both extend
+                    // NumericField, tagName: 'span' (web/static/src/js/
+                    // fields/basic_fields.js), same as Amount in the Take
+                    // Money In/Out wizard -- the " input" suffix is
+                    // required, otherwise "text ..." falls back to
+                    // $element.focusIn(), which raises a TypeError.
                     {
                         content: "Add a cashbox line",
                         trigger: ".o_field_x2many .o_field_x2many_list_row_add a",
                     },
                     {
                         content: "Fill in the Coin/Bill Value",
-                        trigger: ".o_selected_row .o_field_widget[name='coin_value']",
+                        trigger:
+                            ".o_selected_row .o_field_widget[name='coin_value'] input",
                         run: "text 50000",
                     },
                     {
                         content: "Fill in the #Coins/Bills",
-                        trigger: ".o_selected_row .o_field_widget[name='number']",
+                        trigger: ".o_selected_row .o_field_widget[name='number'] input",
                         run: "text 2",
                     },
 
-                    // Flow 5 -- Confirm. The click on the footer button
+                    // Flow 6 -- Confirm. The click on the footer button
                     // moves focus away from the edited row, committing it
                     // before the save handler runs (patterns.md §C
                     // Jebakan 2).

--- a/ssi_financial_accounting/static/tests/tours/account_bank_statement__cash_register_tour.js
+++ b/ssi_financial_accounting/static/tests/tours/account_bank_statement__cash_register_tour.js
@@ -1,0 +1,466 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define(
+    "ssi_financial_accounting.account_bank_statement__cash_register_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // Shared navigation: Financial Accounting > Bank & Cash > Cash
+        // Registers. "Bank & Cash" (level 2) has children so it renders as
+        // a dropdown-toggle; "Cash Registers" (level 3) is a leaf. The
+        // landing menu of the app is "Invoices" (Account Receivable), so no
+        // substring collision guard is needed here (patterns.md §A).
+        function openCashRegistersMenu() {
+            return [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Financial Accounting app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_financial_accounting.menu_root_financial_accounting"]',
+                },
+                {
+                    content: "Open the Bank & Cash menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_financial_accounting.menu_bank_cash"]',
+                },
+                {
+                    content: "Open the Cash Registers menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_financial_accounting.account_cash_register_menu"]',
+                },
+                {
+                    content: "Cash Registers list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Cash Registers)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ];
+        }
+
+        // Open the fixture record identified by its Journal column value
+        // (the Journal column is shown in the tree, unlike the record's
+        // own "name", which is still "/" before the register is posted).
+        function openRecordByJournal(journalName) {
+            return [
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(" + journalName + ") .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ];
+        }
+
+        // IK: docs/account_bank_statement__cash_register/01-create.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_cash_register_create",
+            {test: true, url: "/web"},
+            [].concat(openCashRegistersMenu(), [
+                // Flow 2 -- Click New.
+                {
+                    content: "Click New",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Flow 3 -- Journal (many2one rendered with
+                // widget="selection" -> <select>, gabungan tag+class,
+                // NOT a descendant "input"; field-writing-rules.md
+                // "Field selection" table).
+                {
+                    content: "Select the Journal",
+                    trigger: "select.o_field_widget[name='journal_id']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text Tour Cash Register Create",
+                },
+                // Flow 3 -- Ending Balance (Monetary widget wraps the
+                // input, so " input" is required here). The Count
+                // wizard is a separate, optional path -- see
+                // `10-count.md` -- and is not exercised here.
+                {
+                    content: "Fill in the Ending Balance",
+                    trigger: ".o_field_widget[name='balance_end_real'] input",
+                    run: "text 100.0",
+                },
+
+                // Flow 4 (Inline Action, System group only) -- on the
+                // Policies tab, click Reload Template Policy. Optional
+                // per the IK text, but exercised here to prove the
+                // button actually works, following the precedent in
+                // ssi_customer_invoice_export's create tour.
+                {
+                    content: "Open the Policies tab",
+                    trigger: ".o_notebook .nav-link:contains(Policies)",
+                },
+                {
+                    content: "Click Reload Template Policy",
+                    trigger: "button[name='action_reload_policy_template']",
+                },
+                {
+                    content: "Reload Template Policy call has completed",
+                    trigger: "button[name='action_reload_policy_template']:enabled",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Flow 5 -- Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Post-Condition -- status is New.
+                {
+                    content: "Status is New",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ])
+        );
+
+        // IK: docs/account_bank_statement__cash_register/04-post.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_cash_register_post",
+            {test: true, url: "/web"},
+            [].concat(
+                openCashRegistersMenu(),
+                openRecordByJournal("Tour Cash Register Post"),
+                [
+                    // Flow 3 -- Click Post.
+                    {
+                        content: "Click the Post button",
+                        trigger: ".o_statusbar_buttons button[name='button_post']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Post-Condition -- status is Processing.
+                    {
+                        content: "Status is Processing",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='posted'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__cash_register/05-validate.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_cash_register_validate",
+            {test: true, url: "/web"},
+            [].concat(
+                openCashRegistersMenu(),
+                openRecordByJournal("Tour Cash Register Validate"),
+                [
+                    // Flow 3 -- Click Validate. Fixture Ending Balance
+                    // matches the computed balance (difference = 0), so
+                    // this goes straight to Validated instead of opening
+                    // the closing-balance confirmation wizard.
+                    {
+                        content: "Click the Validate button",
+                        trigger:
+                            ".o_statusbar_buttons button[name='button_validate_or_action']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Post-Condition -- status is Validated.
+                    {
+                        content: "Status is Validated",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__cash_register/06-reset-to-new.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_cash_register" +
+                "_reset_to_new",
+            {test: true, url: "/web"},
+            [].concat(
+                openCashRegistersMenu(),
+                openRecordByJournal("Tour Cash Register Reset New"),
+                [
+                    // Flow 3 -- Click Reset to New.
+                    {
+                        content: "Click the Reset to New button",
+                        trigger: ".o_statusbar_buttons button[name='button_reopen']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Post-Condition -- status is New.
+                    {
+                        content: "Status is New",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__cash_register/07-reset-to-processing.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_cash_register" +
+                "_reset_to_processing",
+            {test: true, url: "/web"},
+            [].concat(
+                openCashRegistersMenu(),
+                openRecordByJournal("Tour Cash Register Reset Processing"),
+                [
+                    // Flow 3 -- Click Reset to Processing.
+                    {
+                        content: "Click the Reset to Processing button",
+                        trigger: ".o_statusbar_buttons button[name='button_reprocess']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Post-Condition -- status is Processing.
+                    {
+                        content: "Status is Processing",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='posted'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__cash_register/08-print.md
+        //
+        // Bounded per odoo-development-ui-test skill, patterns.md §Q: the
+        // Print wizard's own Print button returns a report action with no
+        // DOM "finished" signal (it triggers a PDF download) and is never
+        // clicked here -- the tour only proves the wizard opens with a
+        // report available, then discards it.
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_cash_register_print",
+            {test: true, url: "/web"},
+            [].concat(
+                openCashRegistersMenu(),
+                openRecordByJournal("Tour Cash Register Print"),
+                [
+                    // Flow 3 -- Click Print. The button name is a
+                    // numeric action id in the DOM (id="%(...)d"
+                    // template), never a stable [name=...] -- see
+                    // odoo-development-ui-test skill, patterns-dialogs-
+                    // and-wizards.md §H point 1.
+                    {
+                        content: "Click the Print button",
+                        trigger: ".o_statusbar_buttons button:contains(Print)",
+                        extra_trigger: ".o_form_view",
+                    },
+                    // Flow 4-5 stop here (see module comment above): the
+                    // wizard is shown to be usable, but the Print button
+                    // inside it is not clicked.
+                    {
+                        content: "The Select Report To Print wizard is displayed",
+                        trigger: ".o_form_view",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                    {
+                        content: "A report is available and Print is enabled",
+                        trigger: ".modal-footer button[name='action_print']:enabled",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                    {
+                        content: "Cancel the wizard",
+                        trigger: ".modal-footer button:contains(Cancel)",
+                    },
+                    {
+                        content: "Wizard is closed",
+                        trigger: "body:not(:has(.modal))",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__cash_register/09-take-money-in-out.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_cash_register" +
+                "_take_money_in_out",
+            {test: true, url: "/web"},
+            [].concat(
+                openCashRegistersMenu(),
+                openRecordByJournal("Tour Cash Register Take Money"),
+                [
+                    // Flow 3 -- Click Take Money In/Out. The button name is
+                    // a numeric action id in the DOM (id="%(...)d"
+                    // template), never a stable [name=...] -- see
+                    // odoo-development-ui-test skill, patterns-dialogs-
+                    // and-wizards.md §H point 1.
+                    {
+                        content: "Click the Take Money In/Out button",
+                        trigger:
+                            ".o_statusbar_buttons button:contains(Take Money In/Out)",
+                        extra_trigger: ".o_form_view",
+                    },
+                    {
+                        content: "The Take Money In/Out wizard is displayed",
+                        trigger: ".o_form_view",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+
+                    // Flow 4 -- fill Reason and Amount. Char/Float root
+                    // elements are the <input> itself (no " input" suffix).
+                    {
+                        content: "Fill in the Reason",
+                        trigger: ".o_field_widget[name='name']",
+                        run: "text Tour Cash In",
+                    },
+                    {
+                        content: "Fill in the Amount",
+                        trigger: ".o_field_widget[name='amount']",
+                        run: "text 50",
+                    },
+
+                    // Flow 5 -- confirm the wizard. Single primary button
+                    // in this footer, so no :contains disambiguation
+                    // needed.
+                    {
+                        content: "Confirm Take Money In/Out",
+                        trigger: ".modal-footer button.btn-primary",
+                    },
+
+                    // Post-Condition -- a new transaction line is added.
+                    // "Tour Cash In" could not appear in the list before
+                    // this wizard ran (the fixture starts with zero
+                    // lines), so its appearance is the completion gate
+                    // (odoo-development-ui-test skill, patterns.md §P
+                    // uji lakmus).
+                    {
+                        content: "A new transaction line is added",
+                        trigger: ".o_data_row:contains(Tour Cash In)",
+                        extra_trigger: "body:not(:has(.modal))",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/account_bank_statement__cash_register/10-count.md
+        tour.register(
+            "ssi_financial_accounting_account_bank_statement_cash_register_count",
+            {test: true, url: "/web"},
+            [].concat(
+                openCashRegistersMenu(),
+                openRecordByJournal("Tour Cash Register Count"),
+                [
+                    // Flow 3 -- click the "-> Count" link next to Starting
+                    // Balance. Both Count buttons share the same
+                    // name="open_cashbox_id"; disambiguate structurally by
+                    // the field it sits next to (view XML: both are
+                    // siblings of their balance field inside the same
+                    // <div>).
+                    {
+                        content: "Click Count next to Starting Balance",
+                        trigger:
+                            "div:has(.o_field_widget[name='balance_start']) " +
+                            "button[name='open_cashbox_id']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    {
+                        content: "The cash-count wizard is displayed",
+                        trigger: ".o_form_view",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+
+                    // Flow 4 -- add a denomination line and fill it in.
+                    {
+                        content: "Add a cashbox line",
+                        trigger: ".o_field_x2many .o_field_x2many_list_row_add a",
+                    },
+                    {
+                        content: "Fill in the Coin/Bill Value",
+                        trigger: ".o_selected_row .o_field_widget[name='coin_value']",
+                        run: "text 50000",
+                    },
+                    {
+                        content: "Fill in the #Coins/Bills",
+                        trigger: ".o_selected_row .o_field_widget[name='number']",
+                        run: "text 2",
+                    },
+
+                    // Flow 5 -- Confirm. The click on the footer button
+                    // moves focus away from the edited row, committing it
+                    // before the save handler runs (patterns.md §C
+                    // Jebakan 2).
+                    {
+                        content: "Confirm the cash count",
+                        trigger: ".modal-footer button.btn-primary",
+                    },
+
+                    // Post-Condition -- the counted total is applied to
+                    // the balance. The exact resulting value is
+                    // odoo-development-unit-test territory (Boundary
+                    // §2); this tour only proves the round trip completed
+                    // and the form is back.
+                    {
+                        content: "Wizard is closed",
+                        trigger: "body:not(:has(.modal))",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                    {
+                        content: "Form is back",
+                        trigger: ".o_form_view",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+    }
+);

--- a/ssi_financial_accounting/tests/__init__.py
+++ b/ssi_financial_accounting/tests/__init__.py
@@ -4,3 +4,5 @@
 
 from . import test_ssi_financial_accounting  # noqa: F401
 from . import test_mass_reconcile_advanced_partner  # noqa: F401
+from . import test_ui_account_bank_statement__bank_statement  # noqa: F401
+from . import test_ui_account_bank_statement__cash_register  # noqa: F401

--- a/ssi_financial_accounting/tests/test_ui_account_bank_statement__bank_statement.py
+++ b/ssi_financial_accounting/tests/test_ui_account_bank_statement__bank_statement.py
@@ -86,14 +86,29 @@ class TestUiAccountBankStatementBankStatement(HttpSavepointCase):
                 "counterpart_account_id": cls.reconcile_account.id,
             }
         )
-        cls.statement_validate.write({"state": "posted"})
-        # Regression guard: if the fixture above stops producing a fully
+        # ``balance_end_real`` (account/models/account_bank_statement.py
+        # `_compute_ending_balance`) only depends on
+        # ``previous_statement_id``/its ``balance_end_real`` -- NOT on
+        # ``line_ids``/``line_ids.amount``. So it was already computed to 0
+        # when the statement was created (before the line above existed)
+        # and never recomputes afterwards. Without this write,
+        # ``button_validate`` -> ``_check_bank_balance_end_real_same_as_
+        # computed`` (core, bank journals only) raises "The ending balance
+        # is incorrect !" because ``balance_end`` (line-driven) is 100 while
+        # ``balance_end_real`` is still 0.
+        cls.statement_validate.write({"state": "posted", "balance_end_real": 100.0})
+        # Regression guards: if the fixture above stops producing a fully
         # reconciled statement, `validate_ok` goes False and the
         # ``test_validate`` tour times out on an invisible Validate button
-        # instead of failing here with a clear message.
+        # instead of failing here with a clear message; if the ending
+        # balance stops matching the computed one, `button_validate` raises
+        # a UserError instead of failing here with a clear message.
         assert (
             cls.statement_validate.validate_ok
         ), "Validate fixture is not reconciled: validate_ok is False"
+        assert cls.statement_validate.currency_id.is_zero(
+            cls.statement_validate.difference
+        ), "Validate fixture ending balance does not match the computed one"
 
         cls.journal_reset_new = cls.env["account.journal"].create(
             {"name": "Tour Bank Statement Reset New", "type": "bank", "code": "TBSRN"}

--- a/ssi_financial_accounting/tests/test_ui_account_bank_statement__bank_statement.py
+++ b/ssi_financial_accounting/tests/test_ui_account_bank_statement__bank_statement.py
@@ -50,24 +50,50 @@ class TestUiAccountBankStatementBankStatement(HttpSavepointCase):
             }
         )
 
+        # ``is_reconciled`` is a stored compute (account/models/
+        # account_bank_statement.py `_compute_is_reconciled`) with no
+        # inverse: writing it directly gets silently overwritten by the
+        # next recompute. To make the Validate fixture's line genuinely
+        # reconciled without exercising full manual reconciliation (out of
+        # scope for a UI tour), its counterpart move line is created
+        # against a real account instead of the journal's suspense
+        # account -- ``_seek_for_lines`` then buckets it as an "other"
+        # line, so ``_compute_is_reconciled`` takes the
+        # "no suspense line left" branch and sets ``is_reconciled = True``
+        # on its own.
+        cls.reconcile_account = cls.env["account.account"].create(
+            {
+                "name": "Tour Reconciled Counterpart",
+                "code": "TOURBSRC",
+                "user_type_id": cls.env.ref(
+                    "account.data_account_type_current_assets"
+                ).id,
+                "reconcile": True,
+            }
+        )
+
         cls.journal_validate = cls.env["account.journal"].create(
             {"name": "Tour Bank Statement Validate", "type": "bank", "code": "TBSVA"}
         )
         cls.statement_validate = cls.env["account.bank.statement"].create(
             {"journal_id": cls.journal_validate.id}
         )
-        line_validate = cls.env["account.bank.statement.line"].create(
+        cls.env["account.bank.statement.line"].create(
             {
                 "statement_id": cls.statement_validate.id,
                 "payment_ref": "Tour Test Line",
                 "amount": 100.0,
+                "counterpart_account_id": cls.reconcile_account.id,
             }
         )
-        # Force the line to appear reconciled -- real reconciliation is out
-        # of scope for a UI tour; the tour only exercises the Validate
-        # button once the Pre-Condition is met.
-        line_validate.is_reconciled = True
         cls.statement_validate.write({"state": "posted"})
+        # Regression guard: if the fixture above stops producing a fully
+        # reconciled statement, `validate_ok` goes False and the
+        # ``test_validate`` tour times out on an invisible Validate button
+        # instead of failing here with a clear message.
+        assert (
+            cls.statement_validate.validate_ok
+        ), "Validate fixture is not reconciled: validate_ok is False"
 
         cls.journal_reset_new = cls.env["account.journal"].create(
             {"name": "Tour Bank Statement Reset New", "type": "bank", "code": "TBSRN"}

--- a/ssi_financial_accounting/tests/test_ui_account_bank_statement__bank_statement.py
+++ b/ssi_financial_accounting/tests/test_ui_account_bank_statement__bank_statement.py
@@ -1,0 +1,165 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase -- NOT HttpCase. See odoo-development-ui-test skill,
+# structure-and-runner.md "Base class" -- HttpCase in 14.0 does not set up
+# cls.env in setUpClass.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiAccountBankStatementBankStatement(HttpSavepointCase):
+    """Tour tests for the Bank Statement variant of ``account.bank.statement``.
+
+    IK source: ``docs/account_bank_statement__bank_statement/``. Fixtures use
+    a dedicated journal per tour so each tour's Pre-Condition record is
+    unambiguous in the list view, and set ``state``/``is_reconciled``
+    directly where the IK Pre-Condition only requires the record to already
+    be in that status -- reaching it through the full business flow is
+    covered by the ``04-post``/``05-validate`` tours themselves.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the journals, statements, and access rights the tours need."""
+        super().setUpClass()
+        # user_id is explicit below because cls.env runs as SUPERUSER, and
+        # the tour logs in as "admin" over HTTP -- a real, non-superuser
+        # session subject to groups and record rules.
+        cls.admin = cls.env.ref("base.user_admin")
+        cls.admin.write(
+            {"groups_id": [(4, cls.env.ref("account.group_account_user").id)]}
+        )
+
+        cls.journal_create = cls.env["account.journal"].create(
+            {"name": "Tour Bank Statement Create", "type": "bank", "code": "TBSCR"}
+        )
+
+        cls.journal_post = cls.env["account.journal"].create(
+            {"name": "Tour Bank Statement Post", "type": "bank", "code": "TBSPO"}
+        )
+        cls.statement_post = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_post.id}
+        )
+        cls.env["account.bank.statement.line"].create(
+            {
+                "statement_id": cls.statement_post.id,
+                "payment_ref": "Tour Test Line",
+                "amount": 100.0,
+            }
+        )
+
+        cls.journal_validate = cls.env["account.journal"].create(
+            {"name": "Tour Bank Statement Validate", "type": "bank", "code": "TBSVA"}
+        )
+        cls.statement_validate = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_validate.id}
+        )
+        line_validate = cls.env["account.bank.statement.line"].create(
+            {
+                "statement_id": cls.statement_validate.id,
+                "payment_ref": "Tour Test Line",
+                "amount": 100.0,
+            }
+        )
+        # Force the line to appear reconciled -- real reconciliation is out
+        # of scope for a UI tour; the tour only exercises the Validate
+        # button once the Pre-Condition is met.
+        line_validate.is_reconciled = True
+        cls.statement_validate.write({"state": "posted"})
+
+        cls.journal_reset_new = cls.env["account.journal"].create(
+            {"name": "Tour Bank Statement Reset New", "type": "bank", "code": "TBSRN"}
+        )
+        cls.statement_reset_new = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_reset_new.id}
+        )
+        cls.statement_reset_new.write({"state": "posted"})
+
+        cls.journal_reset_processing = cls.env["account.journal"].create(
+            {
+                "name": "Tour Bank Statement Reset Processing",
+                "type": "bank",
+                "code": "TBSRP",
+            }
+        )
+        cls.statement_reset_processing = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_reset_processing.id}
+        )
+        cls.statement_reset_processing.write({"state": "confirm"})
+
+        cls.journal_print = cls.env["account.journal"].create(
+            {"name": "Tour Bank Statement Print", "type": "bank", "code": "TBSPR"}
+        )
+        cls.statement_print = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_print.id}
+        )
+
+    def test_create(self):
+        """Run the create tour for the Bank Statement variant.
+
+        IK: docs/account_bank_statement__bank_statement/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_bank_statement_create",
+            login="admin",
+        )
+
+    def test_post(self):
+        """Run the post tour for the Bank Statement variant.
+
+        IK: docs/account_bank_statement__bank_statement/04-post.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_bank_statement_post",
+            login="admin",
+        )
+
+    def test_validate(self):
+        """Run the validate tour for the Bank Statement variant.
+
+        IK: docs/account_bank_statement__bank_statement/05-validate.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_bank_statement_validate",
+            login="admin",
+        )
+
+    def test_reset_to_new(self):
+        """Run the reset-to-new tour for the Bank Statement variant.
+
+        IK: docs/account_bank_statement__bank_statement/06-reset-to-new.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_bank_statement"
+            "_reset_to_new",
+            login="admin",
+        )
+
+    def test_reset_to_processing(self):
+        """Run the reset-to-processing tour for the Bank Statement variant.
+
+        IK: docs/account_bank_statement__bank_statement/07-reset-to-processing.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_bank_statement"
+            "_reset_to_processing",
+            login="admin",
+        )
+
+    def test_print(self):
+        """Run the print tour for the Bank Statement variant.
+
+        IK: docs/account_bank_statement__bank_statement/08-print.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_bank_statement_print",
+            login="admin",
+        )

--- a/ssi_financial_accounting/tests/test_ui_account_bank_statement__cash_register.py
+++ b/ssi_financial_accounting/tests/test_ui_account_bank_statement__cash_register.py
@@ -1,0 +1,218 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase -- NOT HttpCase. See odoo-development-ui-test skill,
+# structure-and-runner.md "Base class" -- HttpCase in 14.0 does not set up
+# cls.env in setUpClass.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiAccountBankStatementCashRegister(HttpSavepointCase):
+    """Tour tests for the Cash Register variant of ``account.bank.statement``.
+
+    IK source: ``docs/account_bank_statement__cash_register/``. Fixtures use
+    a dedicated journal per tour so each tour's Pre-Condition record is
+    unambiguous in the list view, and set ``state``/``is_reconciled``
+    directly where the IK Pre-Condition only requires the record to already
+    be in that status -- reaching it through the full business flow is
+    covered by the ``04-post``/``05-validate`` tours themselves.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the journals, statements, and access rights the tours need."""
+        super().setUpClass()
+        # user_id is explicit below because cls.env runs as SUPERUSER, and
+        # the tour logs in as "admin" over HTTP -- a real, non-superuser
+        # session subject to groups and record rules.
+        cls.admin = cls.env.ref("base.user_admin")
+        cls.admin.write(
+            {"groups_id": [(4, cls.env.ref("account.group_account_user").id)]}
+        )
+
+        # Take Money In/Out (09-take-money-in-out.md) requires the company's
+        # Internal Transfer Account to be configured.
+        cls.transfer_account = cls.env["account.account"].create(
+            {
+                "name": "Tour Transfer Account",
+                "code": "TOURXFER",
+                "user_type_id": cls.env.ref(
+                    "account.data_account_type_current_assets"
+                ).id,
+                "reconcile": True,
+            }
+        )
+        cls.env.company.transfer_account_id = cls.transfer_account.id
+
+        cls.journal_create = cls.env["account.journal"].create(
+            {"name": "Tour Cash Register Create", "type": "cash", "code": "TCRCR"}
+        )
+
+        cls.journal_post = cls.env["account.journal"].create(
+            {"name": "Tour Cash Register Post", "type": "cash", "code": "TCRPO"}
+        )
+        cls.statement_post = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_post.id}
+        )
+        cls.env["account.bank.statement.line"].create(
+            {
+                "statement_id": cls.statement_post.id,
+                "payment_ref": "Tour Test Line",
+                "amount": 100.0,
+            }
+        )
+
+        cls.journal_validate = cls.env["account.journal"].create(
+            {"name": "Tour Cash Register Validate", "type": "cash", "code": "TCRVA"}
+        )
+        cls.statement_validate = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_validate.id}
+        )
+        line_validate = cls.env["account.bank.statement.line"].create(
+            {
+                "statement_id": cls.statement_validate.id,
+                "payment_ref": "Tour Test Line",
+                "amount": 100.0,
+            }
+        )
+        # Force the line to appear reconciled -- real reconciliation is out
+        # of scope for a UI tour. Ending Balance is aligned with the
+        # computed balance so the difference is zero: for a cash journal, a
+        # non-zero difference opens the closing-balance confirmation wizard
+        # instead of validating directly (see button_validate_or_action).
+        line_validate.is_reconciled = True
+        cls.statement_validate.write({"state": "posted", "balance_end_real": 100.0})
+
+        cls.journal_reset_new = cls.env["account.journal"].create(
+            {"name": "Tour Cash Register Reset New", "type": "cash", "code": "TCRRN"}
+        )
+        cls.statement_reset_new = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_reset_new.id}
+        )
+        cls.statement_reset_new.write({"state": "posted"})
+
+        cls.journal_reset_processing = cls.env["account.journal"].create(
+            {
+                "name": "Tour Cash Register Reset Processing",
+                "type": "cash",
+                "code": "TCRRP",
+            }
+        )
+        cls.statement_reset_processing = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_reset_processing.id}
+        )
+        cls.statement_reset_processing.write({"state": "confirm"})
+
+        cls.journal_print = cls.env["account.journal"].create(
+            {"name": "Tour Cash Register Print", "type": "cash", "code": "TCRPR"}
+        )
+        cls.statement_print = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_print.id}
+        )
+
+        cls.journal_take_money = cls.env["account.journal"].create(
+            {"name": "Tour Cash Register Take Money", "type": "cash", "code": "TCRTM"}
+        )
+        cls.statement_take_money = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_take_money.id}
+        )
+
+        cls.journal_count = cls.env["account.journal"].create(
+            {"name": "Tour Cash Register Count", "type": "cash", "code": "TCRCT"}
+        )
+        cls.statement_count = cls.env["account.bank.statement"].create(
+            {"journal_id": cls.journal_count.id}
+        )
+
+    def test_create(self):
+        """Run the create tour for the Cash Register variant.
+
+        IK: docs/account_bank_statement__cash_register/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_cash_register_create",
+            login="admin",
+        )
+
+    def test_post(self):
+        """Run the post tour for the Cash Register variant.
+
+        IK: docs/account_bank_statement__cash_register/04-post.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_cash_register_post",
+            login="admin",
+        )
+
+    def test_validate(self):
+        """Run the validate tour for the Cash Register variant.
+
+        IK: docs/account_bank_statement__cash_register/05-validate.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_cash_register_validate",
+            login="admin",
+        )
+
+    def test_reset_to_new(self):
+        """Run the reset-to-new tour for the Cash Register variant.
+
+        IK: docs/account_bank_statement__cash_register/06-reset-to-new.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_cash_register"
+            "_reset_to_new",
+            login="admin",
+        )
+
+    def test_reset_to_processing(self):
+        """Run the reset-to-processing tour for the Cash Register variant.
+
+        IK: docs/account_bank_statement__cash_register/07-reset-to-processing.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_cash_register"
+            "_reset_to_processing",
+            login="admin",
+        )
+
+    def test_print(self):
+        """Run the print tour for the Cash Register variant.
+
+        IK: docs/account_bank_statement__cash_register/08-print.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_cash_register_print",
+            login="admin",
+        )
+
+    def test_take_money_in_out(self):
+        """Run the Take Money In/Out tour for the Cash Register variant.
+
+        IK: docs/account_bank_statement__cash_register/09-take-money-in-out.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_cash_register"
+            "_take_money_in_out",
+            login="admin",
+        )
+
+    def test_count(self):
+        """Run the Count tour for the Cash Register variant.
+
+        IK: docs/account_bank_statement__cash_register/10-count.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_financial_accounting_account_bank_statement_cash_register_count",
+            login="admin",
+        )

--- a/ssi_financial_accounting/tests/test_ui_account_bank_statement__cash_register.py
+++ b/ssi_financial_accounting/tests/test_ui_account_bank_statement__cash_register.py
@@ -64,26 +64,54 @@ class TestUiAccountBankStatementCashRegister(HttpSavepointCase):
             }
         )
 
+        # ``is_reconciled`` is a stored compute (account/models/
+        # account_bank_statement.py `_compute_is_reconciled`) with no
+        # inverse: writing it directly gets silently overwritten by the
+        # next recompute. To make the Validate fixture's line genuinely
+        # reconciled without exercising full manual reconciliation (out of
+        # scope for a UI tour), its counterpart move line is created
+        # against a real account instead of the journal's suspense
+        # account -- ``_seek_for_lines`` then buckets it as an "other"
+        # line, so ``_compute_is_reconciled`` takes the
+        # "no suspense line left" branch and sets ``is_reconciled = True``
+        # on its own.
+        cls.reconcile_account = cls.env["account.account"].create(
+            {
+                "name": "Tour Reconciled Counterpart",
+                "code": "TOURCRRC",
+                "user_type_id": cls.env.ref(
+                    "account.data_account_type_current_assets"
+                ).id,
+                "reconcile": True,
+            }
+        )
+
         cls.journal_validate = cls.env["account.journal"].create(
             {"name": "Tour Cash Register Validate", "type": "cash", "code": "TCRVA"}
         )
         cls.statement_validate = cls.env["account.bank.statement"].create(
             {"journal_id": cls.journal_validate.id}
         )
-        line_validate = cls.env["account.bank.statement.line"].create(
+        cls.env["account.bank.statement.line"].create(
             {
                 "statement_id": cls.statement_validate.id,
                 "payment_ref": "Tour Test Line",
                 "amount": 100.0,
+                "counterpart_account_id": cls.reconcile_account.id,
             }
         )
-        # Force the line to appear reconciled -- real reconciliation is out
-        # of scope for a UI tour. Ending Balance is aligned with the
-        # computed balance so the difference is zero: for a cash journal, a
-        # non-zero difference opens the closing-balance confirmation wizard
-        # instead of validating directly (see button_validate_or_action).
-        line_validate.is_reconciled = True
+        # Ending Balance is aligned with the computed balance so the
+        # difference is zero: for a cash journal, a non-zero difference
+        # opens the closing-balance confirmation wizard instead of
+        # validating directly (see button_validate_or_action).
         cls.statement_validate.write({"state": "posted", "balance_end_real": 100.0})
+        # Regression guard: if the fixture above stops producing a fully
+        # reconciled statement, `validate_ok` goes False and the
+        # ``test_validate`` tour times out on an invisible Validate button
+        # instead of failing here with a clear message.
+        assert (
+            cls.statement_validate.validate_ok
+        ), "Validate fixture is not reconciled: validate_ok is False"
 
         cls.journal_reset_new = cls.env["account.journal"].create(
             {"name": "Tour Cash Register Reset New", "type": "cash", "code": "TCRRN"}

--- a/ssi_financial_accounting/views/assets.xml
+++ b/ssi_financial_accounting/views/assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_financial_accounting assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_financial_accounting/static/tests/tours/account_bank_statement__bank_statement_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_financial_accounting/static/tests/tours/account_bank_statement__cash_register_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) dan tour UI untuk `account.bank.statement`
di `ssi_financial_accounting`, sebagai dua varian sesuai `.ik-entry-point`
(model milik Odoo core, jadi ditulis penuh — bukan delta):

- **Bank Statement** (`docs/account_bank_statement__bank_statement/`, menu
  *Bank Statements*, grup `bank_statement_*`): 8 IK — create, edit, delete,
  post, validate, reset to new, reset to processing, print.
- **Cash Register** (`docs/account_bank_statement__cash_register/`, menu
  *Cash Registers*, grup `cash_register_*`): 10 IK — kedelapan di atas
  ditambah Take Money In/Out dan Count.

14 tour UI pasangan (`static/tests/tours/`) + `tests/test_ui_*.py`. Tour
untuk `02-edit` dan `03-delete` di kedua varian sengaja tidak dibuat
(opsional per tabel cakupan `odoo-development-ui-test`).

`README.rst` mendapat bagian `Work Instruction`. Manifest menambah
dependency `web_tour` + `views/assets.xml` (bundle `web.assets_tests`)
supaya tour bisa dijalankan.

Murni dokumentasi + tour — tidak ada perubahan kode Python/XML modul.

Closes #124

## Test plan

- [x] `validate-ik.sh` — 0 ERROR
- [x] `validate-tour.sh` — 0 ERROR, 0 peringatan
- [x] `pre-commit-gate.sh` — GATE OK (Tahap 0 + 6 validator, 0 pelanggaran baru)
- [ ] CI `test with Odoo` / `test with OCB` — 14 tour dijalankan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tPKQ9dzJ2mGcVQn7dVzma